### PR TITLE
Feature/railtie to patch

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.1.1)
+    getaround_utils (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -4,7 +4,7 @@ Backend shared utility classes
 
 ## Railties
 
-### `GetaroundUtils::Railties::Lograge`
+### GetaroundUtils::Railties::Lograge
 
 Enables lograge (http logs) with favored default.
 ```
@@ -14,19 +14,22 @@ require 'getaround_utils/railties/lograge'
 
 For more details, [read the spec](spec/getaround_utils/railties/lograge_spec.rb)
 
-### `GetaroundUtils::Railties::KeyValueLogTags`
+## Patches
+
+### GetaroundUtils::Patches::KeyValueLogTags
 
 Enables parse-able key-value tags in ActiveRecord::TaggedLogger
 ```
 # config/application.rb
-require 'getaround_utils/railties/key_value_log_tags'
+require 'getaround_utils/patches/key_value_log_tags'
+GetaroundUtils::Patches::KeyValueLogTags.enable
 ```
 
-For more details, [read the spec](spec/getaround_utils/railties/key_value_log_tags.rb)
+For more details, [read the spec](spec/getaround_utils/patches/key_value_log_tags_spec.rb)
 
 ## Misc
 
-### `GetaroundUtils::LogFormatters::DeepKeyValue`
+### GetaroundUtils::LogFormatters::DeepKeyValue
 
 This log formatter will serialize an object of any depth into a key-value string.
 It supports basic scalars (ie: `Hash`,`Array`,`Numeric`,`String`) and will call "#inspect" for any other type.

--- a/getaround_utils/lib/getaround_utils/patches/key_value_log_tags.rb
+++ b/getaround_utils/lib/getaround_utils/patches/key_value_log_tags.rb
@@ -2,16 +2,16 @@ require 'rails/railtie'
 require 'getaround_utils/log_formatters/deep_key_value'
 
 module GetaroundUtils; end
-module GetaroundUtils::Railties; end
+module GetaroundUtils::Patches; end
 
-class GetaroundUtils::Railties::KeyValueLogTags < Rails::Railtie
-  module TaggedLoggingFormatterKeyValueLogTags
+class GetaroundUtils::Patches::KeyValueLogTags
+  module TaggedLoggingFormatter
     def tags_text
       @tags_text ||= "#{current_tags.join(' ')} " if current_tags.any?
     end
   end
 
-  module RackLoggerKeyValueLogTags
+  module RackLogger
     def compute_tags(request)
       @kv_formatter ||= GetaroundUtils::LogFormatters::DeepKeyValue.new
       @taggers.collect do |tag|
@@ -27,8 +27,8 @@ class GetaroundUtils::Railties::KeyValueLogTags < Rails::Railtie
     end
   end
 
-  initializer 'getaround_utils.action_controller' do
-    ActiveSupport::TaggedLogging::Formatter.prepend TaggedLoggingFormatterKeyValueLogTags
-    Rails::Rack::Logger.prepend RackLoggerKeyValueLogTags
+  def self.enable
+    ActiveSupport::TaggedLogging::Formatter.prepend TaggedLoggingFormatter
+    Rails::Rack::Logger.prepend RackLogger
   end
 end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/getaround_utils/spec/getaround_utils/patches/key_value_log_tags_spec.rb
+++ b/getaround_utils/spec/getaround_utils/patches/key_value_log_tags_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'getaround_utils/patches/key_value_log_tags'
 
-describe GetaroundUtils::Railties::KeyValueLogTags do
+describe GetaroundUtils::Patches::KeyValueLogTags do
+  described_class.enable
+
   let(:output) { Tempfile.new }
   let(:logger) { ActiveSupport::TaggedLogging.new(Logger.new(output)) }
 

--- a/getaround_utils/spec/rails_helper.rb
+++ b/getaround_utils/spec/rails_helper.rb
@@ -5,7 +5,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'rails'
 require 'action_controller/railtie'
 require 'getaround_utils/railties/lograge'
-require 'getaround_utils/railties/key_value_log_tags'
 
 class DummyApplication < Rails::Application
   config.load_defaults 6.0


### PR DESCRIPTION
# What?
- Moves `GetaroundUtils::Railties::KeyValueLogTags` into `GetaroundUtils::Patches::KeyValueLogTags`

# Why?

Railties are not really suited for monkey patching as they might be eval'ed too late in the initialisation process