### PR TITLE
getaround_utils: better lograge variables handling

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -9,14 +9,16 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
   module LogrageActionController
     def append_info_to_payload(payload)
       super
-      payload[:host] = request.host
-      payload[:remote_ip] = request.remote_ip
-      payload[:request_id] = request.uuid
-      payload[:user_agent] = request.user_agent
-      payload[:referer] = request.referer
-      payload[:controller_action] = "#{params[:controller]}##{params[:action]}" if params
-      payload[:session_id] = session&.id
-      payload[:user_id] = current_user&.id if defined?(current_user)
+      payload[:lograge] ||= {}
+      payload[:lograge][:host] = request.host
+      payload[:lograge][:params] = request.filtered_parameters.except(:action, :controller)
+      payload[:lograge][:remote_ip] = request.remote_ip
+      payload[:lograge][:request_id] = request.uuid
+      payload[:lograge][:user_agent] = request.user_agent
+      payload[:lograge][:referer] = request.referer
+      payload[:lograge][:controller_action] = "#{params[:controller]}##{params[:action]}" if params
+      payload[:lograge][:session_id] = session&.id
+      payload[:lograge][:user_id] = current_user&.id if defined?(current_user)
     end
   end
 
@@ -27,6 +29,6 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
   config.lograge.enabled = true
   config.lograge.formatter = GetaroundUtils::LogFormatters::DeepKeyValue.new
   config.lograge.custom_options = lambda do |event|
-    event.payload.except(:headers).compact
+    event.payload[:lograge].compact
   end
 end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
# What?
- Saner definition and usage of event payload for http logging

# Why?
So I finally took the time to actually figure this out properly,
 - `append_info_to_payload` is actually an ActiveRecord facility that we should avoid adding / remove key globally as multiple actors can use it (or not)
 - lograge has his own internal logic for using values from the payload (aliasing them as well)
 - `config.lograge.custom_options` return value will be appended to the values set by lograge

