### PR TITLE
Feature/improve key value

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ namespace :gem do
     GEM_NAMES.each do |gem_name|
       desc "Cleanup the #{gem_name} gem artifacts"
       task gem_name do
-        sh "rm #{build_path}/#{gem_name}-*.gem"
+        sh "rm -f #{build_path}/#{gem_name}-*.gem"
       end
     end
 

--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.9.0)
@@ -103,6 +104,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.0)
@@ -133,6 +136,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (10.5.0)
+    redis (4.1.3)
     relaxed-rubocop (2.4)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -167,6 +171,11 @@ GEM
     rubocop-rspec (1.36.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -199,6 +208,7 @@ DEPENDENCIES
   rspec-rails (~> 3.9)
   rubocop (~> 0.75, >= 0.75.0)
   rubocop-rspec (~> 1.36, >= 0.36.0)
+  sidekiq (~> 6.0)
 
 BUNDLED WITH
    2.0.2

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -52,6 +52,19 @@ GetaroundUtils::Patches::KeyValueLogTags.enable
 
 For more details, [read the spec](spec/getaround_utils/patches/key_value_log_tags_spec.rb)
 
+
+### GetaroundUtils::Patches::KeyValueSidekiqExceptions
+
+Enables parse-able exception logging from Sidekiq
+```
+# config/application.rb
+require 'getaround_utils/patches/key_value_sidekiq_exceptions'
+GetaroundUtils::Patches::KeyValueSidekiqExceptions.enable
+```
+
+For more details, [read the spec](spec/getaround_utils/patches/key_value_sidekiq_exceptions_spec.rb)
+
+
 ## Misc
 
 ### GetaroundUtils::LogFormatters::DeepKeyValue

--- a/getaround_utils/getaround_utils.gemspec
+++ b/getaround_utils/getaround_utils.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-rails', '~> 3.9'
   gem.add_development_dependency 'rubocop', '~> 0.75', '>= 0.75.0'
   gem.add_development_dependency 'rubocop-rspec', '~> 1.36', '>= 0.36.0'
+  gem.add_development_dependency 'sidekiq', '~> 6.0'
 end

--- a/getaround_utils/lib/getaround_utils/patches.rb
+++ b/getaround_utils/lib/getaround_utils/patches.rb
@@ -1,3 +1,4 @@
 module GetaroundUtils::Patches
   autoload :KeyValueLogTags, 'getaround_utils/patches/key_value_log_tags'
+  autoload :KeyValueSidekiqExceptions, 'getaround_utils/patches/key_value_sidekiq_exceptions'
 end

--- a/getaround_utils/lib/getaround_utils/patches/key_value_log_tags.rb
+++ b/getaround_utils/lib/getaround_utils/patches/key_value_log_tags.rb
@@ -1,4 +1,3 @@
-require 'rails/railtie'
 require 'getaround_utils/utils/deep_key_value_serializer'
 
 module GetaroundUtils; end

--- a/getaround_utils/lib/getaround_utils/patches/key_value_sidekiq_exceptions.rb
+++ b/getaround_utils/lib/getaround_utils/patches/key_value_sidekiq_exceptions.rb
@@ -1,0 +1,26 @@
+require 'sidekiq/exception_handler'
+require 'getaround_utils/utils/deep_key_value_serializer'
+
+module GetaroundUtils; end
+module GetaroundUtils::Patches; end
+
+class GetaroundUtils::Patches::KeyValueSidekiqExceptions
+  module ExceptionHandlerLogger
+    def kv_formatter
+      @kv_formatter ||= GetaroundUtils::Utils::DeepKeyValueSerializer.new
+    end
+
+    def call(exception, ctx)
+      payload = {}
+      payload[:exception] = exception&.class&.name
+      payload[:sidekiq] = ctx
+      payload[:message] = exception&.message
+      payload[:backtrace] = exception&.backtrace&.join("\n")
+      Sidekiq.logger.warn(kv_formatter.serialize(payload.compact))
+    end
+  end
+
+  def self.enable
+    Sidekiq::ExceptionHandler::Logger.prepend ExceptionHandlerLogger
+  end
+end

--- a/getaround_utils/spec/getaround_utils/patches/key_value_sidekiq_exceptions_spec.rb
+++ b/getaround_utils/spec/getaround_utils/patches/key_value_sidekiq_exceptions_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe GetaroundUtils::Patches::KeyValueSidekiqExceptions do
+  before do
+    stub_logger = Class.new(Sidekiq::ExceptionHandler::Logger)
+    stub_logger.prepend(GetaroundUtils::Patches::KeyValueSidekiqExceptions::ExceptionHandlerLogger)
+    stub_const('Sidekiq::ExceptionHandler::Logger', stub_logger)
+  end
+
+  let(:logger) { Sidekiq::ExceptionHandler::Logger.new }
+
+  describe 'Sidekiq::ExceptionHandler::Logger' do
+    it 'logs the passed exception' do
+      ex = StandardError.new('Dummy')
+      ex.set_backtrace(['/file/dummy:0 in `block in call', '/file/dummy:1 in `block in call'])
+
+      expect(Sidekiq.logger).to receive(:warn)
+        .with(%{exception="StandardError" message="Dummy" backtrace="/file/dummy:0 in `block in call\\n/file/dummy:1 in `block in call"})
+      logger.call(ex, {})
+    end
+
+    it 'logs the passed context' do
+      expect(Sidekiq.logger).to receive(:warn)
+        .with(%{sidekiq.key="value"})
+      logger.call(nil, key: :value)
+    end
+  end
+end

--- a/getaround_utils/spec/getaround_utils/utils/deep_key_value_serializer_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/deep_key_value_serializer_spec.rb
@@ -1,69 +1,101 @@
 require "spec_helper"
 
 describe GetaroundUtils::Utils::DeepKeyValueSerializer do
+  let(:subject) { described_class.new(max_depth: 5, max_length: 512) }
+
   describe '.serialize' do
-    it 'serializes a flat hash with a simple string correctly' do
-      expect(subject.serialize(key: 'value')).to eq('key="value"')
+    context 'with numbers' do
+      it 'serializes a number correctly' do
+        expect(subject.serialize(42)).to eq('42')
+      end
+
+      it 'serializes a nested number correctly' do
+        expect(subject.serialize(value: 42)).to eq('value=42')
+      end
     end
 
-    it 'serializes a flat hash with complex strings correctly' do
-      expect(subject.serialize(key: 'This \ " is &\' weird one   ')).to eq('key="This \\\\ \\" is &\' weird one   "')
+    context 'with strings' do
+      it 'serializes a string correctly' do
+        expect(subject.serialize(' \ " ')).to eq('" \\\\ \" "')
+      end
+
+      it 'serializes a nested string correctly' do
+        expect(subject.serialize(value: ' \ " ')).to eq('value=" \\\\ \" "')
+      end
+
+      it 'serializes an inspect-type string correctly' do
+        expect(subject.serialize('" something "')).to eq('" something "')
+      end
+
+      it 'serializes a nested inspect-type string correctly' do
+        expect(subject.serialize(value: '" something "')).to eq('value=" something "')
+      end
+
+      it 'truncates a value that is too long' do
+        expect(subject.serialize(value: 'a' * 1000)).to eq(%{value="#{'a' * 512} ..."})
+      end
     end
 
-    it 'serializes a flat hash with simple values correctly' do
-      expect(subject.serialize(key: 42.0)).to eq('key=42.0')
+    context 'with arrays' do
+      it 'serializes an array correctly' do
+        expect(subject.serialize(['a', 'b', 'c'])).to eq('0="a" 1="b" 2="c"')
+      end
+
+      it 'serializes a nested array correctly' do
+        expect(subject.serialize(value: ['a', 'b', 'c'])).to eq('value.0="a" value.1="b" value.2="c"')
+      end
+
+      it 'truncates an array that is too deep' do
+        expect(subject.serialize([[[[[['value']]]]]])).to eq('0.0.0.0.0.0="..."')
+      end
     end
 
-    it 'serializes a flat hash with complex values correctly' do
-      expect(subject.serialize(key: Tempfile.new)).to match(/^key="#<File:.+>"$/)
+    context 'with hashes' do
+      it 'serializes a flat hash with a simple string correctly' do
+        expect(subject.serialize(key: 'value')).to eq('key="value"')
+      end
+
+      it 'serializes a flat hash with complex strings correctly' do
+        expect(subject.serialize(key: 'This \ " is &\' weird one   ')).to eq('key="This \\\\ \\" is &\' weird one   "')
+      end
+
+      it 'serializes a flat hash with simple values correctly' do
+        expect(subject.serialize(key: 42.0)).to eq('key=42.0')
+      end
+
+      it 'serializes a flat hash with complex values correctly' do
+        expect(subject.serialize(key: Tempfile.new)).to match(/^key="#<File:.+>"$/)
+      end
+
+      it 'serializes a flat hash with simple array correctly' do
+        expect(subject.serialize(key: ['a', 'b'])).to eq('key.0="a" key.1="b"')
+      end
+
+      it 'serializes a flat hash with complex array correctly' do
+        expect(subject.serialize(key: ['a', 42, 55.123])).to eq('key.0="a" key.1=42 key.2=55.123')
+      end
+
+      it 'serializes a deep hash with a simple payload correctly' do
+        expect(subject.serialize(key1: { key2: { key3: 'value' } })).to eq('key1.key2.key3="value"')
+      end
+
+      it 'serializes a deep hash with a complex payload correctly' do
+        expect(subject.serialize(
+          a1: { b1: { c2: 'value' }, b2: [1, 42.0] }, a2: { b1: 'fifty' }, a3: [{ b3: 'c4' }],
+        )).to eq(
+          'a1.b1.c2="value" a1.b2.0=1 a1.b2.1=42.0 a2.b1="fifty" a3.0.b3="c4"'
+        )
+      end
+
+      it 'truncates a hash that is too deep' do
+        expect(subject.serialize(a: { b: { c: { d: { e: { f: 'value' } } } } })).to eq('a.b.c.d.e.f="..."')
+      end
     end
 
-    it 'serializes a flat hash with simple array correctly' do
-      expect(subject.serialize(key: ['a', 'b'])).to eq('key.0="a" key.1="b"')
-    end
-
-    it 'serializes a flat hash with complex array correctly' do
-      expect(subject.serialize(key: ['a', 42, 55.123])).to eq('key.0="a" key.1=42 key.2=55.123')
-    end
-
-    it 'serializes a deep hash with a simple payload correctly' do
-      expect(subject.serialize(key1: { key2: { key3: 'value' } })).to eq('key1.key2.key3="value"')
-    end
-
-    it 'serializes a deep hash with a complex payload correctly' do
-      expect(subject.serialize(
-        a1: { b1: { c2: 'value' }, b2: [1, 42.0] }, a2: { b1: 'fifty' }, a3: [{ b3: 'c4' }],
-      )).to eq(
-        'a1.b1.c2="value" a1.b2.0=1 a1.b2.1=42.0 a2.b1="fifty" a3.0.b3="c4"'
-      )
-    end
-
-    it 'serializes a number correctly' do
-      expect(subject.serialize(42)).to eq('42')
-    end
-
-    it 'serializes a nested number correctly' do
-      expect(subject.serialize(value: 42)).to eq('value=42')
-    end
-
-    it 'serializes a string correctly' do
-      expect(subject.serialize(' \ " ')).to eq('" \\\\ \" "')
-    end
-
-    it 'serializes a nested string correctly' do
-      expect(subject.serialize(value: ' \ " ')).to eq('value=" \\\\ \" "')
-    end
-
-    it 'serializes an inspect-type string correctly' do
-      expect(subject.serialize('" something "')).to eq('" something "')
-    end
-
-    it 'serializes a nested inspect-type string correctly' do
-      expect(subject.serialize(value: '" something "')).to eq('value=" something "')
-    end
-
-    it 'serializes an object correctly' do
-      expect(subject.serialize(value: Tempfile.new)).to match(/^value="#<File.+>"$/)
+    context 'with objects' do
+      it 'serializes an object correctly' do
+        expect(subject.serialize(value: Tempfile.new)).to match(/^value="#<File.+>"$/)
+      end
     end
   end
 end


### PR DESCRIPTION
# What ?
Final overhaul of the logging ecosystem, this build upon the previous iteration to provide stable key-value-everywhere™ logging
- `Formatters::DeepKeyValue` now formats passed string as a `message=""`.
- `Formatters::DeepKeyValue` is now guarded against over-encoding already formatted strings.
- String emitted in the `DeepKeyValueSerializer` are now truncated to (by default) 512 chars
- Hashes and Arrays emitted in the `DeepKeyValueSerializer` are now truncated to a depth of (by default) 5
- `Patches::KeyValueSidekiqExceptions` is pretty self-explanatory

# Why ?
 - Strings are forwarded and reasonably guaranteed to be merged in a way that won't break key-value parsing
 - Patches::KeyValueSidekiqExceptions covers one of the last remaining piece of hardcoded formatting in the stack