### PR TITLE
Refactor of DeepKeyValue classes/modules for simple (re)usability

### DIFF
--- a/getaround_utils/lib/getaround_utils/log_formatters/deep_key_value.rb
+++ b/getaround_utils/lib/getaround_utils/log_formatters/deep_key_value.rb
@@ -1,36 +1,46 @@
 module GetaroundUtils; end
 module GetaroundUtils::LogFormatters; end
 
-require 'getaround_utils/utils/deep_key_value_serializer'
+require 'getaround_utils/utils/deep_key_value'
 
-class GetaroundUtils::LogFormatters::DeepKeyValue < GetaroundUtils::Utils::DeepKeyValueSerializer
-  def normalize(message)
-    if message.is_a?(Hash)
-      serialize(message.compact)
-    elsif message.is_a?(String) && message.match(/^[^ =]+=/)
-      message
-    else
-      serialize(message: message.to_s)
+class GetaroundUtils::LogFormatters::DeepKeyValue
+  module Shared
+    def normalize(message)
+      if message.is_a?(Hash)
+        GetaroundUtils::Utils::DeepKeyValue.serialize(message.compact)
+      elsif message.is_a?(String) && message.match(/^[^ =]+=/)
+        message
+      else
+        GetaroundUtils::Utils::DeepKeyValue.serialize(message: message.to_s)
+      end
     end
   end
 
-  def call(severity, _datetime, appname, message)
-    payload = { severity: severity, appname: appname }
-    "#{normalize(payload)} #{normalize(message)}\n"
+  class Base
+    include GetaroundUtils::LogFormatters::DeepKeyValue::Shared
+
+    def call(severity, _datetime, appname, message)
+      payload = { severity: severity, appname: appname }
+      "#{normalize(payload)} #{normalize(message)}\n"
+    end
   end
 
-  module Lograge
+  def self.new
+    Base.new
+  end
+
+  class Lograge
     def call(message)
       message = message.compact if message.is_a?(Hash)
-      serialize(message)
+      GetaroundUtils::Utils::DeepKeyValue.serialize(message)
     end
   end
 
   def self.for_lograge
-    new.extend(Lograge)
+    Lograge.new
   end
 
-  module Sidekiq
+  class Sidekiq < Base
     def sidekiq_context
       context = Thread.current&.fetch(:sidekiq_context, nil)
       context.is_a?(Hash) ? context : {}
@@ -48,6 +58,6 @@ class GetaroundUtils::LogFormatters::DeepKeyValue < GetaroundUtils::Utils::DeepK
   end
 
   def self.for_sidekiq
-    new.extend(Sidekiq)
+    Sidekiq.new
   end
 end

--- a/getaround_utils/lib/getaround_utils/mixins/loggable.rb
+++ b/getaround_utils/lib/getaround_utils/mixins/loggable.rb
@@ -24,15 +24,11 @@ module GetaroundUtils::Mixins::Loggable
     end
   end
 
-  def loggable_formatter
-    @loggable_formatter ||= GetaroundUtils::Utils::DeepKeyValueSerializer.new
-  end
-
   def loggable(severity, message, payload = {})
     payload = { message: message }.merge(payload)
     base_append_infos_to_loggable(payload)
 
-    message = loggable_formatter.serialize(payload.compact)
+    message = GetaroundUtils::Utils::DeepKeyValue.serialize(payload.compact)
     base_loggable_logger.send(severity.to_sym, message)
   end
 end

--- a/getaround_utils/lib/getaround_utils/patches/key_value_sidekiq_exceptions.rb
+++ b/getaround_utils/lib/getaround_utils/patches/key_value_sidekiq_exceptions.rb
@@ -1,22 +1,18 @@
 require 'sidekiq/exception_handler'
-require 'getaround_utils/utils/deep_key_value_serializer'
+require 'getaround_utils/utils/deep_key_value'
 
 module GetaroundUtils; end
 module GetaroundUtils::Patches; end
 
 class GetaroundUtils::Patches::KeyValueSidekiqExceptions
   module ExceptionHandlerLogger
-    def kv_formatter
-      @kv_formatter ||= GetaroundUtils::Utils::DeepKeyValueSerializer.new
-    end
-
     def call(exception, ctx)
       payload = {}
       payload[:message] = exception.message
       payload[:exception] = exception.class.name
       payload[:backtrace] = exception.backtrace&.join("\n")
       payload[:sidekiq] = ctx
-      Sidekiq.logger.warn(kv_formatter.serialize(payload.compact))
+      Sidekiq.logger.warn(GetaroundUtils::Utils::DeepKeyValue.serialize(payload.compact))
     end
   end
 

--- a/getaround_utils/lib/getaround_utils/utils.rb
+++ b/getaround_utils/lib/getaround_utils/utils.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils::Utils
-  autoload :DeepKeyValueSerializer, 'getaround_utils/utils/deep_key_value_serializer'
+  autoload :DeepKeyValue, 'getaround_utils/utils/deep_key_value'
 end

--- a/getaround_utils/lib/getaround_utils/utils/deep_key_value.rb
+++ b/getaround_utils/lib/getaround_utils/utils/deep_key_value.rb
@@ -1,13 +1,8 @@
 module GetaroundUtils; end
 module GetaroundUtils::Utils; end
 
-class GetaroundUtils::Utils::DeepKeyValueSerializer
-  def initialize(max_depth: 5, max_length: 512)
-    @max_depth = max_depth
-    @max_length = max_length
-  end
-
-  def serialize(data)
+module GetaroundUtils::Utils::DeepKeyValue
+  def self.serialize(data)
     case data
     when Array
       flattify(data).map { |key, value| "#{key}=#{value}" }.join(' ')
@@ -23,31 +18,31 @@ class GetaroundUtils::Utils::DeepKeyValueSerializer
   end
 
   # https://stackoverflow.com/questions/48836464/how-to-flatten-a-hash-making-each-key-a-unique-value
-  def flattify(value, result = {}, path = [])
-    if path.length > @max_depth
+  def self.flattify(value, result = {}, path = [], max_length = 512, max_depth = 5)
+    if path.length > max_depth
       result[path.join(".")] = '"..."'
       return result
     end
     case value
     when Array
       value.each.with_index(0) do |v, i|
-        flattify(v, result, path + [i])
+        flattify(v, result, path + [i], max_length, max_depth)
       end
     when Hash
       value.each do |k, v|
-        flattify(v, result, path + [k])
+        flattify(v, result, path + [k], max_length, max_depth)
       end
     when Numeric
       result[path.join(".")] = value.to_s
     when String
       value = if value =~ /^".*"$/
-        value.length >= @max_length ? %{#{value[0...@max_length]} ..."} : value
+        value.length >= max_length ? %{#{value[0...max_length]} ..."} : value
       else
-        value.length >= @max_length ? %{#{value[0...@max_length]} ...}.inspect : value.inspect
+        value.length >= max_length ? %{#{value[0...max_length]} ...}.inspect : value.inspect
       end
       result[path.join(".")] = value
     else
-      flattify(value.to_s, result, path)
+      flattify(value.to_s, result, path, max_length, max_depth)
     end
     result
   end

--- a/getaround_utils/spec/getaround_utils/log_formatters/deep_key_value_spec.rb
+++ b/getaround_utils/spec/getaround_utils/log_formatters/deep_key_value_spec.rb
@@ -1,77 +1,100 @@
+require 'logger'
 require "spec_helper"
 
 describe GetaroundUtils::LogFormatters::DeepKeyValue do
-  describe '.for_lograge' do
-    let(:formatter) { described_class.for_lograge }
+  describe GetaroundUtils::LogFormatters::DeepKeyValue::Base do
+    context 'when using via a Logger' do
+      let(:output) { Tempfile.new }
+      let(:logger) do
+        logger = Logger.new(output)
+        logger.formatter = subject
+        logger
+      end
 
-    it 'return a formatter variant that only takes one parametter' do
-      expect(formatter.call('string')).to eq('"string"')
-      expect(formatter.call(['a'])).to eq('0="a"')
-      expect(formatter.call(key: :value)).to eq('key="value"')
+      it 'works with raw Strings' do
+        expect(output).to receive(:write)
+          .with(%{severity="INFO" message="string"\n})
+        logger.info('string')
+      end
+
+      it 'works with formatted Strings' do
+        expect(output).to receive(:write)
+          .with(%{severity="INFO" key=value\n})
+        logger.info('key=value')
+      end
+
+      it 'works with extra long strings' do
+        expect(output).to receive(:write)
+          .with(%{severity="INFO" message="#{'x' * 512} ..."\n})
+        logger.info('x' * 1000)
+      end
+
+      it 'works with progname' do
+        expect(output).to receive(:write)
+          .with(%{severity="INFO" appname="dummy" message="string"\n})
+        logger.info('dummy') { 'string' }
+      end
+
+      it 'works with Hashes' do
+        expect(output).to receive(:write)
+          .with(%{severity="INFO" key="value"\n})
+        logger.info(key: 'value')
+      end
     end
   end
 
-  describe '.for_sidekiq' do
-    let(:formatter) { described_class.for_sidekiq }
+  describe 'legacy'  do
+    describe '.new'  do
+      it 'return a Base variant' do
+        expect(described_class.new).to be_a(GetaroundUtils::LogFormatters::DeepKeyValue::Base)
+      end
+    end
 
-    it 'return a formatter variant that appends sidekiq context to string message' do
-      expect(formatter.call(:info, nil, 'dummy', 'string'))
+    describe '.for_lograge' do
+      it 'return a Lograge variant' do
+        expect(described_class.for_lograge).to be_a(GetaroundUtils::LogFormatters::DeepKeyValue::Lograge)
+      end
+    end
+
+    describe '.for_sidekiq' do
+      it 'return a Sidekiq variant' do
+        expect(described_class.for_sidekiq).to be_a(GetaroundUtils::LogFormatters::DeepKeyValue::Sidekiq)
+      end
+    end
+  end
+
+  describe GetaroundUtils::LogFormatters::DeepKeyValue::Sidekiq do
+    let(:subject) { described_class.new }
+
+    it 'appends sidekiq context to string message' do
+      expect(subject.call(:info, nil, 'dummy', 'string'))
         .to match(/^severity="info" appname="dummy" message="string" sidekiq.tid="[a-z0-9]{9}"\n$/m)
     end
 
-    it 'return a formatter variant that appends sidekiq context to string formatted message' do
+    it 'appends sidekiq context to string formatted message' do
       Thread.current[:sidekiq_context] = { key: :value1 }
-      expect(formatter.call(:info, nil, 'dummy', 'key="value"'))
+      expect(subject.call(:info, nil, 'dummy', 'key="value"'))
         .to match(/^severity="info" appname="dummy" key="value" sidekiq.key="value1" sidekiq.tid="[a-z0-9]{9}"\n$/m)
     ensure
       Thread.current[:sidekiq_context] = nil
     end
 
-    it 'return a formatter variant that appends sidekiq context to hash messages' do
+    it 'appends sidekiq context to hash messages' do
       Thread.current[:sidekiq_context] = { key: :value2 }
-      expect(formatter.call(:info, nil, 'dummy', key: :value ))
+      expect(subject.call(:info, nil, 'dummy', key: :value ))
         .to match(/^severity="info" appname="dummy" key="value" sidekiq.key="value2" sidekiq.tid="[a-z0-9]{9}"\n$/m)
     ensure
       Thread.current[:sidekiq_context] = nil
     end
   end
 
-  context 'when using via a Logger' do
-    let(:output) { Tempfile.new }
-    let(:logger) do
-      logger = Logger.new(output)
-      logger.formatter = subject
-      logger
-    end
+  describe GetaroundUtils::LogFormatters::DeepKeyValue::Lograge do
+    let(:subject) { described_class.new }
 
-    it 'works with raw Strings' do
-      expect(output).to receive(:write)
-        .with(%{severity="INFO" message="string"\n})
-      logger.info('string')
-    end
-
-    it 'works with formatted Strings' do
-      expect(output).to receive(:write)
-        .with(%{severity="INFO" key=value\n})
-      logger.info('key=value')
-    end
-
-    it 'works with extra long strings' do
-      expect(output).to receive(:write)
-        .with(%{severity="INFO" message="#{'x' * 512} ..."\n})
-      logger.info('x' * 1000)
-    end
-
-    it 'works with progname' do
-      expect(output).to receive(:write)
-        .with(%{severity="INFO" appname="dummy" message="string"\n})
-      logger.info('dummy') { 'string' }
-    end
-
-    it 'works with Hashes' do
-      expect(output).to receive(:write)
-        .with(%{severity="INFO" key="value"\n})
-      logger.info(key: 'value')
+    it 'only takes one parametter' do
+      expect(subject.call('string')).to eq('"string"')
+      expect(subject.call(['a'])).to eq('0="a"')
+      expect(subject.call(key: :value)).to eq('key="value"')
     end
   end
 end

--- a/getaround_utils/spec/getaround_utils/patches/key_value_log_tags_spec.rb
+++ b/getaround_utils/spec/getaround_utils/patches/key_value_log_tags_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe GetaroundUtils::Patches::KeyValueLogTags do
   before do
@@ -17,13 +17,13 @@ describe GetaroundUtils::Patches::KeyValueLogTags do
   describe 'ActiveSupport::TaggedLogging::Formatter' do
     it 'does nothing in the absence of tags' do
       expect(output).to receive(:write)
-        .with("string01\n")
-      logger.error('string01')
+        .with(%{message="string01"\n})
+      logger.error('message="string01"')
     end
 
     it 'insert tags without encolsing them in brackets' do
       expect(output).to receive(:write)
-        .with("tag01 tag02 string02\n")
+        .with(%{tag01 tag02 message="string02"\n})
       logger.tagged(['tag01', 'tag02']) { |logger| logger.error('string02') }
     end
   end
@@ -38,7 +38,7 @@ describe GetaroundUtils::Patches::KeyValueLogTags do
       allow(middleware).to receive(:logger).and_return(logger)
 
       expect(output).to receive(:write)
-        .with(%{"tag01" something\n})
+        .with(%{"tag01" message="something"\n})
       middleware.call(Rack::MockRequest.env_for("http://test.com"))
     end
 
@@ -47,7 +47,7 @@ describe GetaroundUtils::Patches::KeyValueLogTags do
       allow(middleware).to receive(:logger).and_return(logger)
 
       expect(output).to receive(:write)
-        .with(%{host="test.com" something\n})
+        .with(%{host="test.com" message="something"\n})
       middleware.call(Rack::MockRequest.env_for("http://test.com"))
     end
 
@@ -56,7 +56,7 @@ describe GetaroundUtils::Patches::KeyValueLogTags do
       allow(middleware).to receive(:logger).and_return(logger)
 
       expect(output).to receive(:write)
-        .with(%{key="value" something\n})
+        .with(%{key="value" message="something"\n})
       middleware.call(Rack::MockRequest.env_for("http://test.com"))
     end
   end

--- a/getaround_utils/spec/getaround_utils/utils/deep_key_value_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/deep_key_value_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe GetaroundUtils::Utils::DeepKeyValueSerializer do
-  let(:subject) { described_class.new(max_depth: 5, max_length: 512) }
+describe GetaroundUtils::Utils::DeepKeyValue do
+  let(:subject) { described_class }
 
   describe '.serialize' do
     context 'with numbers' do


### PR DESCRIPTION
# What?
- Refactor to eliminate extraneous aggregation of `GetaroundUtils::Utils::DeepKeyValueSerializer`
- Refactor to eliminate "ah-hoc" generation of Lograge and Sidekiq variants
