### PR TITLE
getaround_utils Fix Utils::HttpReporter rescue condition

### DIFF
--- a/getaround_utils/lib/getaround_utils/utils/async_queue.rb
+++ b/getaround_utils/lib/getaround_utils/utils/async_queue.rb
@@ -32,12 +32,14 @@ class GetaroundUtils::Utils::AsyncQueue
 
         @worker = Thread.new do
           while args = @queue.pop
-            perform(*args)
+            begin
+              perform(*args)
+            rescue ClosedQueueError
+              nil
+            rescue StandardError => e
+              loggable('error', e.message, class: e.class.to_s, backtrace: e.backtrace)
+            end
           end
-        rescue ClosedQueueError
-          nil
-        rescue StandardError => e
-          loggable('error', e.message, class: e.class.to_s, backtrace: e.backtrace)
         end
 
         at_exit { terminate }

--- a/getaround_utils/spec/getaround_utils/utils/async_queue_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/async_queue_spec.rb
@@ -77,5 +77,19 @@ describe GetaroundUtils::Utils::AsyncQueue do
       expect(dummy_class).to have_received(:loggable)
         .with('error', 'Test error', hash_including(class: 'StandardError'))
     end
+
+    it 'keeps working after rescuing an error' do
+      allow(dummy_class).to receive(:loggable)
+      allow(dummy_class).to receive(:perform)
+        .and_raise(StandardError, 'Test error')
+
+      dummy_class.perform_async(1)
+      dummy_class.perform_async(1)
+      dummy_class.perform_async(1)
+      dummy_class.terminate
+
+      expect(dummy_class).to have_received(:loggable)
+        .exactly(3).times.with('error', 'Test error', hash_including(class: 'StandardError'))
+    end
   end
 end


### PR DESCRIPTION
# What?
In the `Utils::AsyncQueue` class, move the thread rescue condition inside the loop.

# Why?
This caused the thread to die after rescuing an error leaving the queue to overflow