### PR TITLE
getaround_utils: Mixin::Loggable Add specs about use in static class

### DIFF
--- a/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
+++ b/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
@@ -1,18 +1,68 @@
 require 'spec_helper'
 
 describe GetaroundUtils::Mixins::Loggable do
+  let(:dummy_logger) { double }
+
+  context 'when included in a static class' do
+    before do
+      allow(base_class).to receive(:base_loggable_logger)
+        .and_return(dummy_logger)
+    end
+
+    let(:base_class) do
+      stub_const('BaseClass', Class.new{
+        class << self
+          include GetaroundUtils::Mixins::Loggable
+
+          def use_loggable(*args)
+            loggable(*args)
+          end
+        end
+      })
+    end
+
+    it 'injects the class name' do
+      expect(dummy_logger).to receive(:error)
+        .with('message="test" origin="BaseClass"')
+      base_class.use_loggable(:error, 'test')
+    end
+
+    it 'inject the appended info' do
+      base_class.class_eval do
+        def self.append_infos_to_loggable(payload)
+          payload[:extra] = 'dummy'
+        end
+      end
+
+      expect(dummy_logger).to receive(:info)
+        .with('message="dummy" key="value" origin="BaseClass" extra="dummy"')
+      base_class.use_loggable(:info, 'dummy', key: :value)
+    end
+  end
+
   context 'when included in a class' do
-    let(:dummy_logger) { double }
-    let(:base_class) { stub_const('BaseClass', Class.new { include GetaroundUtils::Mixins::Loggable }) }
+    let(:base_class) do
+      stub_const('BaseClass', Class.new{
+        include GetaroundUtils::Mixins::Loggable
+
+        def use_loggable(*args)
+          loggable(*args)
+        end
+      })
+    end
+
     let(:subject) { base_class.new }
 
-    before { allow(subject).to receive(:base_loggable_logger).and_return(dummy_logger) }
+    before do
+      allow(subject).to receive(:base_loggable_logger)
+        .and_return(dummy_logger)
+    end
 
     context 'with no inheritence' do
       it 'inject the class name' do
         expect(dummy_logger).to receive(:info)
           .with('message="dummy" key="value" origin="BaseClass"')
-        subject.loggable(:info, 'dummy', key: :value)
+        subject.use_loggable(:info, 'dummy', key: :value)
       end
 
       it 'inject the appended info' do
@@ -24,7 +74,7 @@ describe GetaroundUtils::Mixins::Loggable do
 
         expect(dummy_logger).to receive(:info)
           .with('message="dummy" key="value" origin="BaseClass" extra="dummy"')
-        subject.loggable(:info, 'dummy', key: :value)
+        subject.use_loggable(:info, 'dummy', key: :value)
       end
     end
 
@@ -35,7 +85,7 @@ describe GetaroundUtils::Mixins::Loggable do
       it 'inject the class name' do
         expect(dummy_logger).to receive(:info)
           .with('message="dummy" key="value" origin="ChildClass"')
-        subject.loggable(:info, 'dummy', key: :value)
+        subject.use_loggable(:info, 'dummy', key: :value)
       end
 
       it 'inherits the parent appended infos' do
@@ -47,7 +97,7 @@ describe GetaroundUtils::Mixins::Loggable do
 
         expect(dummy_logger).to receive(:info)
           .with('message="dummy" key="value" origin="ChildClass" parent="dummy"')
-        subject.loggable(:info, 'dummy', key: :value)
+        subject.use_loggable(:info, 'dummy', key: :value)
       end
 
       it 'merges the parent the appended info' do
@@ -65,7 +115,7 @@ describe GetaroundUtils::Mixins::Loggable do
 
         expect(dummy_logger).to receive(:info)
           .with('message="dummy" key="value" origin="ChildClass" parent="dummy" child="dummy"')
-        subject.loggable(:info, 'dummy', key: :value)
+        subject.use_loggable(:info, 'dummy', key: :value)
       end
     end
   end


### PR DESCRIPTION
# What?
 - Include a spec to test the usage of `GetaroundUtils::Mixins::Loggable` within a static class (as opposed to a class instance)
 - Refactor the specs for other cases

# Why?
Static classes in ruby are a bit hacky and it's not really clear how it could work with including modules into them.