### PR TITLE
Feature/utils async queue

### DIFF
--- a/getaround_utils/lib/getaround_utils/utils.rb
+++ b/getaround_utils/lib/getaround_utils/utils.rb
@@ -2,4 +2,5 @@ module GetaroundUtils::Utils
   autoload :AsyncQueue, 'getaround_utils/utils/async_queue'
   autoload :DeepKeyValue, 'getaround_utils/utils/deep_key_value'
   autoload :HttpReporter, 'getaround_utils/utils/http_reporter'
+  autoload :CapturReporter, 'getaround_utils/utils/captur_reporter'
 end

--- a/getaround_utils/lib/getaround_utils/utils/captur_reporter.rb
+++ b/getaround_utils/lib/getaround_utils/utils/captur_reporter.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'faraday'
+require 'getaround_utils/utils/async_queue'
+
+class GetaroundUtils::Utils::CapturReporter < GetaroundUtils::Utils::AsyncQueue
+  CAPTUR_URL = ENV['CAPTUR_URL']
+
+  def perform(events)
+    return unless CAPTUR_URL&.match('^https?://')
+
+    Faraday.post(CAPTUR_URL) do |req|
+      req.options[:open_timeout] = 1
+      req.options[:timeout] = 1
+      req.headers = { 'Content-Type': 'application/json' }
+      req.body = JSON.generate(events: events, metas: metas)
+    end
+  end
+
+  def metas
+    {}
+  end
+
+  def push(uuid:, type:, anonymous_id:, timestamp: nil, attributes: {})
+    super(
+      uuid: uuid,
+      type: type,
+      timestamp: timestamp || Time.now.iso8601,
+      anonymous_id: anonymous_id,
+      attributes: attributes,
+    )
+  end
+end

--- a/getaround_utils/lib/getaround_utils/utils/http_reporter.rb
+++ b/getaround_utils/lib/getaround_utils/utils/http_reporter.rb
@@ -1,29 +1,11 @@
-require 'json'
-require 'faraday'
-require 'getaround_utils/utils/async_queue'
-
 class GetaroundUtils::Utils::HttpReporter
-  class AsyncQueue < GetaroundUtils::Utils::AsyncQueue
-    def self.perform(url:, params: {}, headers: {}, body: nil)
-      Faraday.post(url) do |req|
-        req.options[:open_timeout] = 1
-        req.options[:timeout] = 1
-        req.params = params
-        req.headers = headers
-        req.body = body
-      end
-    end
+  include GetaroundUtils::Mixins::Loggable
+
+  def initialize(_)
+    loggable_log(:warn, 'use of deprecated class')
   end
 
-  def initialize(url:)
-    @url = url
-  end
-
-  def report(event)
-    AsyncQueue.perform_async(
-      url: @url,
-      headers: { 'Content-Type' => 'application/json' },
-      body: JSON.generate(event)
-    )
+  def report(_)
+    loggable_log(:warn, 'use of deprecated class')
   end
 end

--- a/getaround_utils/spec/getaround_utils/utils/captur_reporter_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/captur_reporter_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe GetaroundUtils::Utils::CapturReporter do
+  let(:url) { 'https://test.com/push/getaround_utils-rspec' }
+  let(:metas) { Hash(metas_key: 'meta_value') }
+  let(:subject) { described_class.new }
+  let(:timestamp) { DateTime.now.iso8601 }
+
+  let(:event) { Hash(uuid: '00000000-0000-0000-0000-000000000001', type: :event, timestamp: timestamp, anonymous_id: 'unknown', attributes: { id: '1' }) }
+
+  before do
+    stub_const("#{described_class.name}::CAPTUR_URL", url)
+  end
+
+  after do
+    subject.terminate
+  end
+
+  describe 'functional tests' do
+    it 'posts the event payload to the configured endpoint' do
+      stub = stub_request(:post, url).with(
+        headers: { 'Content-Type' => 'application/json' },
+        body: { events: [event], metas: {} }.to_json,
+      )
+      subject.push(event)
+      subject.terminate
+      expect(stub).to have_been_requested
+    end
+
+    it 'groups events together' do
+      stub = stub_request(:post, url).with(
+        headers: { 'Content-Type' => 'application/json' },
+        body: { events: [event, event], metas: {} }.to_json,
+      )
+      subject.push(event)
+      subject.push(event)
+      subject.terminate
+      expect(stub).to have_been_requested
+    end
+
+    it 'allow describing custom metas' do
+      stub = stub_request(:post, url).with(
+        headers: { 'Content-Type' => 'application/json' },
+        body: { events: [event], metas: metas }.to_json,
+      )
+      allow(subject).to receive(:metas)
+        .and_return(metas)
+      subject.push(event)
+      subject.terminate
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/getaround_utils/spec/getaround_utils/utils/http_reporter_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/http_reporter_spec.rb
@@ -5,18 +5,7 @@ describe GetaroundUtils::Utils::HttpReporter do
   let(:dummy_class) { Class.new(described_class) }
   let(:subject) { dummy_class.new(url: url) }
 
-  after do
-    dummy_class::AsyncQueue.reset
-  end
-
-  it 'posts the event payload to the configured endpoint' do
-    stub = stub_request(:post, "https://test.com/report").with(
-      headers: { 'Content-Type' => 'application/json' },
-      body: '{"key":"value"}',
-    )
-    subject.report(key: :value)
-    dummy_class::AsyncQueue.terminate
-
-    expect(stub).to have_been_requested
+  it 'perfroms a noop' do
+    expect{ subject.report(key: :value) }.not_to raise_error
   end
 end


### PR DESCRIPTION
# What?
 - Deprecate `Getaround::Utils::HttpReporter` (now a NoOp, with a warning)
 - Rewrite `Getaround::Utils::AsyncQueue` into a instantiable class
 - Add `Getaround::Utils::CapturReporter` which sends batched events in the new `Captur` format

# Why?
 - Batching payloads was impossible with the current implementation
 - Captur recently got a endpoint for batched events, which a improved format
 - Testing of the `HttpReporter` in production showed some failure for high volume of events, this should reduce stress on the Captur service.