### PR TITLE
Feature/getaround utils json msg

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.2)
+    getaround_utils (0.2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/ougai/json_formatter.rb
+++ b/getaround_utils/lib/getaround_utils/ougai/json_formatter.rb
@@ -7,8 +7,7 @@ module GetaroundUtils::Ougai; end
 
 class GetaroundUtils::Ougai::JsonFormatter < Ougai::Formatters::Base
   def _call(severity, _time, progname, data)
-    message = data.delete(:msg)
-    data[:message] = message if message != 'No message'
+    data.delete(:msg) if message == 'No message'
 
     payload = { severity: severity, progname: progname }.merge(data).compact!
     JSON.dump(payload) + "\n"

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end


### PR DESCRIPTION
# What?
User the `:msg` property when loggin in json format

# Why?
Workaround a limitation of fluentd/newrelic to allow fulltext search
