### PR TITLE
Fix/classic logger support

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.5)
+    getaround_utils (0.2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/mixins/loggable.rb
+++ b/getaround_utils/lib/getaround_utils/mixins/loggable.rb
@@ -34,6 +34,6 @@ module GetaroundUtils::Mixins::Loggable
 
   def loggable_log(severity, message, payload = {})
     base_append_infos_to_loggable(payload)
-    base_loggable_logger.send(severity.to_sym, message, payload)
+    base_loggable_logger.send(severity.to_sym, { msg: message, **payload })
   end
 end

--- a/getaround_utils/lib/getaround_utils/mixins/loggable.rb
+++ b/getaround_utils/lib/getaround_utils/mixins/loggable.rb
@@ -34,6 +34,6 @@ module GetaroundUtils::Mixins::Loggable
 
   def loggable_log(severity, message, payload = {})
     base_append_infos_to_loggable(payload)
-    base_loggable_logger.send(severity.to_sym, { msg: message, **payload })
+    base_loggable_logger.send(severity.to_sym, msg: message, **payload)
   end
 end

--- a/getaround_utils/lib/getaround_utils/ougai/deep_key_value_formatter.rb
+++ b/getaround_utils/lib/getaround_utils/ougai/deep_key_value_formatter.rb
@@ -6,7 +6,7 @@ require 'getaround_utils/utils/deep_key_value'
 module GetaroundUtils; end
 module GetaroundUtils::Ougai; end
 
-class GetaroundUtils::Ougai::DeepKeyValuesFormatter < Ougai::Formatters::Base
+class GetaroundUtils::Ougai::DeepKeyValueFormatter < Ougai::Formatters::Base
   def _call(severity, _time, progname, data)
     message = data.delete(:msg)
     data[:message] = message if message != 'No message'

--- a/getaround_utils/lib/getaround_utils/railties/ougai.rb
+++ b/getaround_utils/lib/getaround_utils/railties/ougai.rb
@@ -45,7 +45,7 @@ class GetaroundUtils::Railties::Ougai < Rails::Railtie
   config.ougai_logger = OugaiRailsLogger.new(STDOUT)
   config.ougai_logger.after_initialize if Rails::VERSION::MAJOR < 6
   config.ougai_logger.level = log_level
-  config.ougai_logger.formatter = GetaroundUtils::Ougai::DeepKeyValuesFormatter.new
+  config.ougai_logger.formatter = GetaroundUtils::Ougai::DeepKeyValueFormatter.new
   config.ougai_logger.before_log = lambda do |data|
     request_store = RequestStore.store[:ougai] || {}
     data.merge!(request_store) if request_store&.any?

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
+++ b/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
@@ -27,7 +27,7 @@ describe GetaroundUtils::Mixins::Loggable do
 
     it 'injects the class name' do
       expect(dummy_logger).to receive(:error)
-        .with('test', origin: 'BaseClass')
+        .with(msg: 'test', origin: 'BaseClass')
       base_class.use_loggable(:error, 'test')
     end
 
@@ -39,13 +39,13 @@ describe GetaroundUtils::Mixins::Loggable do
       end
 
       expect(dummy_logger).to receive(:info)
-        .with('dummy', key: :value, origin: 'BaseClass', extra: 'dummy')
+        .with(msg: 'dummy', key: :value, origin: 'BaseClass', extra: 'dummy')
       base_class.use_loggable(:info, 'dummy', key: :value)
     end
 
     it 'log warning calling the deprecated function name' do
       expect(dummy_logger).to receive(:error)
-        .with('test', origin: 'BaseClass')
+        .with(msg: 'test', origin: 'BaseClass')
       expect(dummy_logger).to receive(:warn)
       base_class.use_deprecated_loggable(:error, 'test')
     end
@@ -76,7 +76,7 @@ describe GetaroundUtils::Mixins::Loggable do
     context 'with no inheritence' do
       it 'inject the class name' do
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'BaseClass')
+          .with(msg: 'dummy', key: :value, origin: 'BaseClass')
         subject.use_loggable(:info, 'dummy', key: :value)
       end
 
@@ -88,13 +88,13 @@ describe GetaroundUtils::Mixins::Loggable do
         end
 
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'BaseClass', extra: 'dummy')
+          .with(msg: 'dummy', key: :value, origin: 'BaseClass', extra: 'dummy')
         subject.use_loggable(:info, 'dummy', key: :value)
       end
 
       it 'log warning calling the deprecated function name' do
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'BaseClass')
+          .with(msg: 'dummy', key: :value, origin: 'BaseClass')
         expect(dummy_logger).to receive(:warn)
         subject.use_deprecated_loggable(:info, 'dummy', key: :value)
       end
@@ -106,7 +106,7 @@ describe GetaroundUtils::Mixins::Loggable do
 
       it 'inject the class name' do
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'ChildClass')
+          .with(msg: 'dummy', key: :value, origin: 'ChildClass')
         subject.use_loggable(:info, 'dummy', key: :value)
       end
 
@@ -118,7 +118,7 @@ describe GetaroundUtils::Mixins::Loggable do
         end
 
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'ChildClass', parent: 'dummy')
+          .with(msg: 'dummy', key: :value, origin: 'ChildClass', parent: 'dummy')
         subject.use_loggable(:info, 'dummy', key: :value)
       end
 
@@ -136,7 +136,7 @@ describe GetaroundUtils::Mixins::Loggable do
         end
 
         expect(dummy_logger).to receive(:info)
-          .with('dummy', key: :value, origin: 'ChildClass', parent: 'dummy', child: 'dummy')
+          .with(msg: 'dummy', key: :value, origin: 'ChildClass', parent: 'dummy', child: 'dummy')
         subject.use_loggable(:info, 'dummy', key: :value)
       end
     end

--- a/getaround_utils/spec/getaround_utils/ougai/deep_key_value_formatter_spec.rb
+++ b/getaround_utils/spec/getaround_utils/ougai/deep_key_value_formatter_spec.rb
@@ -2,27 +2,27 @@
 
 require 'spec_helper'
 
-describe GetaroundUtils::Ougai::DeepKeyValuesFormatter do
+describe GetaroundUtils::Ougai::DeepKeyValueFormatter do
   subject { described_class.new }
 
   describe '#_call' do
     it 'correctly formats a string' do
-      expect(subject._call('INFO', nil, nil, { msg: 'string' }))
+      expect(subject._call('INFO', nil, nil, msg: 'string'))
         .to eq(%{severity="INFO" message="string"\n})
     end
 
     it 'correctly formats a payload' do
-      expect(subject._call('INFO', nil, nil, { msg: 'string', key: :value }))
+      expect(subject._call('INFO', nil, nil, msg: 'string', key: :value))
         .to eq(%{severity="INFO" key="value" message="string"\n})
     end
 
     it 'ignore empty messages' do
-      expect(subject._call('INFO', nil, nil, { msg: 'No message', key: :value }))
+      expect(subject._call('INFO', nil, nil, msg: 'No message', key: :value))
         .to eq(%{severity="INFO" key="value"\n})
     end
 
     it 'include appname when provided' do
-      expect(subject._call('INFO', nil, 'appname', { msg: 'string', key: :value }))
+      expect(subject._call('INFO', nil, 'appname', msg: 'string', key: :value))
         .to eq(%{severity="INFO" progname="appname" key="value" message="string"\n})
     end
   end

--- a/getaround_utils/spec/getaround_utils/ougai/json_formatter_spec.rb
+++ b/getaround_utils/spec/getaround_utils/ougai/json_formatter_spec.rb
@@ -7,22 +7,22 @@ describe GetaroundUtils::Ougai::JsonFormatter do
 
   describe '#_call' do
     it 'correctly formats a string' do
-      expect(subject._call('INFO', nil, nil, { msg: 'string' }))
+      expect(subject._call('INFO', nil, nil, msg: 'string'))
         .to eq(%{{"severity":"INFO","caption":"string"}\n})
     end
 
     it 'correctly formats a payload' do
-      expect(subject._call('INFO', nil, nil, { msg: 'string', key: :value }))
+      expect(subject._call('INFO', nil, nil, msg: 'string', key: :value))
         .to eq(%{{"severity":"INFO","caption":"string","key":"value"}\n})
     end
 
     it 'ignore empty messages' do
-      expect(subject._call('INFO', nil, nil, { msg: 'No message', key: :value }))
+      expect(subject._call('INFO', nil, nil, msg: 'No message', key: :value))
         .to eq(%{{"severity":"INFO","key":"value"}\n})
     end
 
     it 'include appname when provided' do
-      expect(subject._call('INFO', nil, 'appname', { msg: 'string', key: :value }))
+      expect(subject._call('INFO', nil, 'appname', msg: 'string', key: :value))
         .to eq(%{{"severity":"INFO","progname":"appname","caption":"string","key":"value"}\n})
     end
   end

--- a/getaround_utils/spec/getaround_utils/railties/ougai_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/ougai_spec.rb
@@ -7,9 +7,9 @@ describe GetaroundUtils::Railties::Ougai do
       expect(Rails.logger).to be_a(OugaiRailsLogger)
     end
 
-    describe 'uses GetaroundUtils::Ougai::DeepKeyValuesFormatter by default' do
+    describe 'uses GetaroundUtils::Ougai::DeepKeyValueFormatter by default' do
       it 'setup a child logger as the Rails logger' do
-        expect(Rails.logger.formatter).to be_a(GetaroundUtils::Ougai::DeepKeyValuesFormatter)
+        expect(Rails.logger.formatter).to be_a(GetaroundUtils::Ougai::DeepKeyValueFormatter)
       end
     end
 


### PR DESCRIPTION
# What?
- In Loggable, always pass payload as a message argument
- Bump to 0.2.5

# Why?
 - Compatibility with classic (not Ougai) Logger call signature
 - Fix crashes in drivy-rails in development