### PR TITLE
getaround_utils: fix log_level handling

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.6)
+    getaround_utils (0.2.7)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/railties/ougai.rb
+++ b/getaround_utils/lib/getaround_utils/railties/ougai.rb
@@ -40,11 +40,8 @@ class OugaiRequestStoreMiddleware
 end
 
 class GetaroundUtils::Railties::Ougai < Rails::Railtie
-  log_level = ENV.fetch('LOG_LEVEL', :info).to_sym
-
   config.ougai_logger = OugaiRailsLogger.new(STDOUT)
   config.ougai_logger.after_initialize if Rails::VERSION::MAJOR < 6
-  config.ougai_logger.level = log_level
   config.ougai_logger.formatter = GetaroundUtils::Ougai::DeepKeyValueFormatter.new
   config.ougai_logger.before_log = lambda do |data|
     request_store = RequestStore.store[:ougai] || {}
@@ -55,15 +52,6 @@ class GetaroundUtils::Railties::Ougai < Rails::Railtie
   end
 
   initializer :getaround_utils_ougai, before: :initialize_logger do |app|
-    LOG_LEVELS = {
-      Logger::DEBUG => :debug,
-      Logger::INFO => :info,
-      Logger::WARN => :warn,
-      Logger::ERROR => :error,
-      Logger::FATAL => :fatal,
-    }.freeze
-
-    app.config.log_level = LOG_LEVELS[config.ougai_logger.level] || :info
     app.config.logger = config.ougai_logger
   end
 

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.2.7'.freeze
 end

--- a/getaround_utils/spec/rails_helper.rb
+++ b/getaround_utils/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'getaround_utils/railties/ougai'
 class DummyApplication < Rails::Application
   config.load_defaults 6.0
   config.eager_load = false
+  config.log_level = :info
 end
 
 Rails.application.initialize!


### PR DESCRIPTION
# What?
- Completely defer log_level handling to rails

# Why?
- The log_level is manipulated by a bunch of actors in during Rails initialisation and it's near impossible to partake without side effects
- Previous mechanism prevented user from overriding the log_level in configuration 

# Caveats
The gem does not provide a safe default for the log level anymore, it must be set manually (ie: `config.log_level`)