### PR TITLE
getaround_utils: Feature/fix tagged logging compatibility

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.7)
+    getaround_utils (0.2.8)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/railties/ougai.rb
+++ b/getaround_utils/lib/getaround_utils/railties/ougai.rb
@@ -4,6 +4,7 @@ require 'getaround_utils/ougai/deep_key_value_formatter'
 require 'request_store'
 require 'rails/railtie'
 require 'ougai'
+require 'pry'
 
 module GetaroundUtils; end
 module GetaroundUtils::Railties; end
@@ -19,9 +20,13 @@ end
 # https://github.com/tilfin/ougai/wiki/Use-as-Rails-logger#with-activesupporttaggedlogging
 module OugaiTaggedLoggingFormatter
   def call(severity, time, progname, data)
-    data = { msg: data.to_s } unless data.is_a?(Hash)
-    data[:tags] = current_tags if current_tags.any?
-    _call(severity, time, progname, data)
+    if is_a?(Ougai::Formatters::Base)
+      data = { msg: data.to_s } unless data.is_a?(Hash)
+      data[:tags] = current_tags if current_tags.any?
+      _call(severity, time, progname, data)
+    else
+      super
+    end
   end
 end
 

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.7'.freeze
+  VERSION = '0.2.8'.freeze
 end

--- a/getaround_utils/spec/getaround_utils/railties/ougai_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/ougai_spec.rb
@@ -81,7 +81,7 @@ describe GetaroundUtils::Railties::Ougai do
       base_logger = OugaiRailsLogger.new(STDOUT)
       logger = ActiveSupport::TaggedLogging.new(base_logger)
       expect(logger.formatter).to receive(:_call)
-        .with('WARN', kind_of(Time), nil,  msg: "message", tags: ["tag"])
+        .with('WARN', kind_of(Time), nil, msg: "message", tags: ["tag"])
       logger.tagged('tag') { logger.warn('message') }
     end
   end


### PR DESCRIPTION
# What?
- Add a path in `TaggedLoggingFormatter` to support non-Ougai logger
- Add specs
- Bump to 0.2.8

# Why?
- Some users still chose to use the default rails logger in specific ENVs, which causes a crash or undefined behavior