### PR TITLE
getaround_utils: Feature/better loggable logger

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.9)
+    getaround_utils (0.2.10)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/mixins/loggable.rb
+++ b/getaround_utils/lib/getaround_utils/mixins/loggable.rb
@@ -14,26 +14,16 @@ module GetaroundUtils::Mixins::Loggable
     append_infos_to_loggable(payload)
   end
 
-  def base_loggable_logger
-    @base_loggable_logger ||= if respond_to?(:logger) && !logger.nil?
-      logger
-    elsif defined?(Rails)
-      Rails.logger
-    else
-      Logger.new(STDOUT)
-    end
+  def loggable_logger_fallback
+    @loggable_logger_fallback ||= Logger.new(STDOUT)
   end
 
-  def loggable(severity, message, payload = {})
-    base_loggable_logger.send(
-      :warn,
-      "Deprecated usage of GetaroundUtils::Mixins::Loggable#loggable(*args). Please use GetaroundUtils::Mixins::Loggable#loggable_log(*args) instead"
-    )
-    loggable_log(severity, message, payload)
+  def loggable_logger
+    (logger if respond_to?(:logger)) || (Rails.logger if defined?(Rails)) || loggable_logger_fallback
   end
 
   def loggable_log(severity, message, payload = {})
     base_append_infos_to_loggable(payload)
-    base_loggable_logger.send(severity.to_sym, msg: message, **payload)
+    loggable_logger.send(severity.to_sym, msg: message, **payload)
   end
 end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.9'.freeze
+  VERSION = '0.2.10'.freeze
 end


### PR DESCRIPTION
# What?
 - Rewrite the logic for selecting a output logger
 - Bump to 0.2.10

# Why?
 - The logic could sometimes (ie: Rails before initialisation) select a logger that was `nil`
