### PR TITLE
getaround_utils: Fix Sidekiq error_handler without a Ougai logger

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.10)
+    getaround_utils (0.2.11)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/lib/getaround_utils/railties/ougai.rb
+++ b/getaround_utils/lib/getaround_utils/railties/ougai.rb
@@ -81,9 +81,13 @@ class GetaroundUtils::Railties::Ougai < Rails::Railtie
     Sidekiq.logger = config.ougai_logger
 
     Sidekiq.configure_server do |config|
-      config.error_handlers.shift
+      original_handler = config.error_handlers.shift
       config.error_handlers << lambda do |ex, ctx|
-        Sidekiq.logger.warn(ex, job: ctx[:job])
+        if Sidekiq.logger.is_a?(Ougai::Logger)
+          Sidekiq.logger.warn(ex, job: ctx[:job])
+        else
+          original_handler.call(ex, ctx)
+        end
       end
     end
   end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,3 +1,3 @@
 module GetaroundUtils
-  VERSION = '0.2.10'.freeze
+  VERSION = '0.2.11'.freeze
 end


### PR DESCRIPTION
# What?
- Use default handler in custom Sidekiq error_handler when `Sidekiq.logger` is not a `Ougai::Logger`

# Why?
- See #38 for a similar bug
- Using a classic logger (ie: in drivy-rails@dev) would crash because of the method signature differences.