### PR TITLE
Add lograge "origin" property

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -18,6 +18,7 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
       payload[:lograge][:referer] = request.referer
       payload[:lograge][:session_id] = session.is_a?(Hash) ? session[:id] : session.id.to_s if defined?(session)
       payload[:lograge][:user_id] = current_user&.id if defined?(current_user)
+      payload[:lograge][:origin] = 'lograge'
     end
   end
 

--- a/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
@@ -57,6 +57,7 @@ describe GetaroundUtils::Railties::Lograge, type: :controller do
         expect(payload[:controller]).to eq('AnonymousController')
         expect(payload[:action]).to eq('dummy')
         expect(payload[:view]).to be_a(Float)
+        expect(payload[:origin]).to eq('lograge')
       end
       get(:dummy, params: { key: 'dummy' })
     end


### PR DESCRIPTION
# What?
- Add the `"origin": "lograge"` property to lograge logs for identifications

# Why?
- Easier differentiation of Heroku router vs Logage