### PR TITLE
GetaroundUtils: Add NewRelic trace and span ids

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -19,6 +19,11 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
       payload[:lograge][:session_id] = session.is_a?(Hash) ? session[:id] : session.id.to_s if defined?(session)
       payload[:lograge][:user_id] = current_user&.id if defined?(current_user)
       payload[:lograge][:origin] = 'lograge'
+
+      return unless defined?(Newrelic::Agent::Tracer)
+
+      payload[:lograge]["span.id"] = Newrelic::Agent::Tracer.span_id
+      payload[:lograge]["trace.id"] = Newrelic::Agent::Tracer.trace_id
     end
   end
 

--- a/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
@@ -43,6 +43,30 @@ describe GetaroundUtils::Railties::Lograge, type: :controller do
       }
     end
 
+    context 'with the newrelic trace infos' do
+      it 'return no values when newrelic module is not loaded' do
+        expect(Rails.logger).to receive(:info) do |payload|
+          expect(payload["trace.id"]).to eq(nil)
+          expect(payload["span.id"]).to eq(nil)
+        end
+        get(:dummy, params: { key: 'dummy' })
+      end
+
+      it 'return ids when newrelic module is loaded' do
+        stub_const('Newrelic::Agent::Tracer', Class.new{})
+        allow( Newrelic::Agent::Tracer).to receive(:trace_id)
+          .and_return("12345")
+        allow( Newrelic::Agent::Tracer).to receive(:span_id)
+          .and_return("6789")
+
+        expect(Rails.logger).to receive(:info) do |payload|
+          expect(payload["trace.id"]).to eq("12345")
+          expect(payload["span.id"]).to eq("6789")
+        end
+        get(:dummy, params: { key: 'dummy' })
+      end
+    end
+
     # Values set by lograge
     # method, path, format, controller, action, status, duration, view, (db)
     # location,


### PR DESCRIPTION
What?
--
- Add some NewRelic attributes to our generic log library

Why?
--
In order to activate logs in context feature for NewRelic APM, we need to add some attributes to logs and collects values from NewRelic module.
Here is how official log formatter works: https://github.com/newrelic/newrelic-ruby-agent/blob/dev/lib/new_relic/agent/logging.rb#L58-L65