### PR TITLE
Getaround_utils: Fix NewRelic trace existance check

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -20,10 +20,16 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
       payload[:lograge][:user_id] = current_user&.id if defined?(current_user)
       payload[:lograge][:origin] = 'lograge'
 
-      return unless defined?(Newrelic::Agent::Tracer)
+      if defined?(NewRelic::Agent::Tracer)
+        if span_id = NewRelic::Agent::Tracer.span_id
+          payload[:lograge]["span.id"] = span_id
+        end
+        if trace_id = NewRelic::Agent::Tracer.trace_id
+          payload[:lograge]["trace.id"] = trace_id
+        end
+      end
 
-      payload[:lograge]["span.id"] = Newrelic::Agent::Tracer.span_id
-      payload[:lograge]["trace.id"] = Newrelic::Agent::Tracer.trace_id
+      nil
     end
   end
 

--- a/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
@@ -53,10 +53,10 @@ describe GetaroundUtils::Railties::Lograge, type: :controller do
       end
 
       it 'return ids when newrelic module is loaded' do
-        stub_const('Newrelic::Agent::Tracer', Class.new{})
-        allow( Newrelic::Agent::Tracer).to receive(:trace_id)
+        stub_const('NewRelic::Agent::Tracer', Class.new{})
+        allow(NewRelic::Agent::Tracer).to receive(:trace_id)
           .and_return("12345")
-        allow( Newrelic::Agent::Tracer).to receive(:span_id)
+        allow(NewRelic::Agent::Tracer).to receive(:span_id)
           .and_return("6789")
 
         expect(Rails.logger).to receive(:info) do |payload|


### PR DESCRIPTION
What?
--
- Fix wrong NewRelic module name
- Add not null check for span_id an trace_id as in NewRelic log formatter