### PR TITLE
getaround_utils: Add more NewRelic metadatas in logs to link events to APM trace

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -22,11 +22,18 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
 
       if defined?(NewRelic::Agent::Tracer)
         if span_id = NewRelic::Agent::Tracer.span_id
-          payload[:lograge]["span.id"] = span_id
+          payload[:lograge]['span.id'] = span_id
         end
         if trace_id = NewRelic::Agent::Tracer.trace_id
-          payload[:lograge]["trace.id"] = trace_id
+          payload[:lograge]['trace.id'] = trace_id
         end
+        payload[:lograge]['entity.type'] = 'SERVICE'
+        payload[:lograge]['entity.guid'] = NewRelic::Agent.config[:entity_guid]
+        payload[:lograge]['entity.name'] = NewRelic::Agent.config[:app_name]&.first
+      end
+
+      if defined?(NewRelic::Agent::Hostname)
+        payload[:lograge]['hostname'] = NewRelic::Agent::Hostname.get
       end
 
       nil

--- a/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
+++ b/getaround_utils/spec/getaround_utils/railties/lograge_spec.rb
@@ -54,14 +54,23 @@ describe GetaroundUtils::Railties::Lograge, type: :controller do
 
       it 'return ids when newrelic module is loaded' do
         stub_const('NewRelic::Agent::Tracer', Class.new{})
+        stub_const('NewRelic::Agent::Hostname', Class.new{})
+        allow(NewRelic::Agent).to receive(:config)
+          .and_return({ entity_guid: "azerty", app_name: ["my_app_name"] })
         allow(NewRelic::Agent::Tracer).to receive(:trace_id)
           .and_return("12345")
         allow(NewRelic::Agent::Tracer).to receive(:span_id)
           .and_return("6789")
+        allow(NewRelic::Agent::Hostname).to receive(:get)
+          .and_return("my_hostname")
 
         expect(Rails.logger).to receive(:info) do |payload|
           expect(payload["trace.id"]).to eq("12345")
           expect(payload["span.id"]).to eq("6789")
+          expect(payload["entity.guid"]).to eq("azerty")
+          expect(payload["entity.name"]).to eq("my_app_name")
+          expect(payload["entity.type"]).to eq("SERVICE")
+          expect(payload["hostname"]).to eq("my_hostname")
         end
         get(:dummy, params: { key: 'dummy' })
       end


### PR DESCRIPTION
What?
--
- Add more NewRelic metadatas in logs traces

Why?
--
- Linking traces and logs as done in official library
https://github.com/newrelic/newrelic-ruby-agent/blob/da8c453cbdf4526dad7b49ee8a8558ad63ac2ab6/lib/new_relic/agent.rb#L732