### PR TITLE
getaround_utils: deep_merge lograge params

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/lograge.rb
+++ b/getaround_utils/lib/getaround_utils/railties/lograge.rb
@@ -53,6 +53,6 @@ class GetaroundUtils::Railties::Lograge < Rails::Railtie
     event.payload[:lograge]
   }
   config.lograge.before_format = ->(data, _) {
-    data.except(*HTTP_PARAMS).merge(http: data.slice(*HTTP_PARAMS))
+    data.except(*HTTP_PARAMS).deep_merge(http: data.slice(*HTTP_PARAMS))
   }
 end


### PR DESCRIPTION
# What?
In the lograge Railties, use `deep_merge` to move the `http` namespace

# Why?
This allows for adding values into the `http` hash in controllers