### PR TITLE
Feature/monitorable log

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.22)
+    getaround_utils (0.2.23)
 
 GEM
   remote: https://rubygems.org/
@@ -235,4 +235,4 @@ DEPENDENCIES
   webmock (~> 3.7)
 
 BUNDLED WITH
-   2.2.26
+   2.3.4

--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.23)
+    getaround_utils (0.2.22)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -28,8 +28,8 @@ For more details, [read the spec](spec/getaround_utils/railties/ougai_spec.rb)
 
 ### GetaroundUtils::Mixins::Loggable
 
-Enables lograge (http logs) with favored default.
-```
+- Enables lograge (http logs) with favored default.
+```ruby
 class MyClass
   include GetaroundUtils::Mixins::Loggable
 
@@ -47,6 +47,31 @@ MyClass.new.action # :info message="hello" origin="MyClass" static="value" dynam
 ```
 
 For more details, [read the spec](spec/getaround_utils/mixins/loggable_spec.rb)
+
+- Offers an abstraction to log messages with a configurable `alert_threshold` attribute
+
+```ruby
+class MyClass
+  include GetaroundUtils::Mixins::Loggable
+
+  def action
+    monitorable_log(:my_event_to_be_monitored, dynamic: 'value')
+  end
+end
+
+MyClass.new.action # :info message="monitorable_log__my_event_to_be_monitored" origin="MyClass" dynamic="value", threshold=10
+```
+The threshold is configured in the relevant Rails configuration (eg `config/environments/production.rb`)
+```ruby
+# ...
+  config.monitorable_log_thresholds = {
+    my_event_to_be_monitored: 10
+  }
+# ...
+```
+You may set / override the configured thresholds with an environment variable of the event name prefixed with `MONITORABLE_LOG__`, for instance `MONITORABLE_LOG__MY_EVENT_TO_BE_MONITORED`.
+
+For more details, [read the spec](spec/getaround_utils/mixins/loggable_spec.rb#L171)
 
 ## Misc
 

--- a/getaround_utils/lib/getaround_utils/mixins/loggable.rb
+++ b/getaround_utils/lib/getaround_utils/mixins/loggable.rb
@@ -29,4 +29,20 @@ module GetaroundUtils::Mixins::Loggable
     base_append_infos_to_loggable(payload)
     loggable_logger.send(severity.to_sym, msg: message, **payload)
   end
+
+  MONITORABLE_LOG_PREFIX = "monitorable_log__"
+
+  def monitorable_log(event_name, **options)
+    log_message = MONITORABLE_LOG_PREFIX + event_name
+    configuration_threshold = Rails.application.config.monitorable_log_thresholds[event_name.to_sym] if defined?(Rails)
+    alert_threshold = ENV["#{log_message}_threshold".upcase]&.to_i || configuration_threshold
+    return if alert_threshold.blank?
+
+    loggable_log(
+      :info,
+      log_message,
+      alert_threshold: alert_threshold,
+      **options
+    )
+  end
 end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetaroundUtils
-  VERSION = '0.2.23'
+  VERSION = '0.2.22'
 end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetaroundUtils
-  VERSION = '0.2.22'
+  VERSION = '0.2.23'
 end

--- a/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
+++ b/getaround_utils/spec/getaround_utils/mixins/loggable_spec.rb
@@ -175,7 +175,7 @@ describe GetaroundUtils::Mixins::Loggable do
       allow(base_class).to receive(:loggable_logger)
         .and_return(dummy_logger)
       allow(Rails.application.config.monitorable_log_thresholds)
-        .to receive(:[])
+        .to receive(:dig)
         .with(event_name.to_sym)
         .and_return(10)
     end
@@ -232,7 +232,7 @@ describe GetaroundUtils::Mixins::Loggable do
         allow(base_class).to receive(:loggable_logger)
           .and_return(dummy_logger)
         allow(Rails.application.config.monitorable_log_thresholds)
-          .to receive(:[])
+          .to receive(:dig)
           .with(event_name.to_sym)
           .and_return(nil)
       end

--- a/getaround_utils/spec/rails_helper.rb
+++ b/getaround_utils/spec/rails_helper.rb
@@ -14,6 +14,7 @@ class DummyApplication < Rails::Application
   config.load_defaults 6.0
   config.eager_load = false
   config.log_level = :info
+  config.monitorable_log_thresholds = {}
 end
 
 Rails.application.initialize!


### PR DESCRIPTION
## Notes
The 1st commit is an opportunistic bump of ruby version to `2.7.4` (same as `drivy-rails`).

## Context

In some situations, we want to be able to monitor the number of occurrences of a certain event compared to a given threshold. 
This new `monitorable_log` method allows to trace the occurence of an event, while specifying in the configuration the threshold that should apply to this event.

## Implementation
The logic resides in this new method of the `GetaroundUtils` module.
```
def monitorable_log(event_name, **options)
    log_message = MONITORABLE_LOG_PREFIX + event_name
    configuration_threshold = Rails.application.config.monitorable_log_thresholds[event_name.to_sym] if defined?(Rails)
    alert_threshold = ENV["#{log_message}_threshold".upcase]&.to_i || configuration_threshold
    return if alert_threshold.blank?

    loggable_log(
      :info,
      log_message,
      alert_threshold: alert_threshold,
      **options
    )
end
```