### PR TITLE
Add GetaroundUtils::Railties::Dotenv for homogenous Dotenv config

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
       rexml
     crass (1.0.6)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     getaround-rubocop (0.2.7)
       relaxed-rubocop (= 2.5)
@@ -220,6 +224,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  dotenv-rails (~> 2.7.6)
   getaround-rubocop (= 0.2.7)
   getaround_utils!
   lograge (~> 0.12.0)

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -4,6 +4,31 @@ Backend shared utility classes
 
 ## Railties
 
+### GetaroundUtils::Railties::Dotenv
+
+Enable currated .env files loading
+```
+# config/application.rb
+require 'getaround_utils/railties/dotenv'
+
+GetaroundUtils::Railties::Dotenv.load
+```
+
+Additional files can be loaded with the highed precedence via the `DOTENVS` variable, ie:
+```
+DOTENVS=custom1,custom2 rails c
+# Will `load` .env files in the following order:
+# - `.env.custom1.local`
+# - `.env.custom1`
+# - `.env.custom2.local`
+# - `.env.custom2`
+# - `.env.<RAILS_ENV>.local`
+# - `.env.<RAILS_ENV>`
+# - `.env.all.local`
+# - `.env.all`
+# - `.env.local`
+```
+
 ### GetaroundUtils::Railties::Lograge
 
 Enables lograge (http logs) with favored default.

--- a/getaround_utils/getaround_utils.gemspec
+++ b/getaround_utils/getaround_utils.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 3.7'
 
   # Functional (optional) dependencies
+  gem.add_development_dependency 'dotenv-rails', '~> 2.7.6'
   gem.add_development_dependency 'lograge', '~> 0.12.0'
   gem.add_development_dependency 'ougai', '~> 2.0'
   gem.add_development_dependency 'rails', '~> 6.0'

--- a/getaround_utils/lib/getaround_utils/railties/dotenv.rb
+++ b/getaround_utils/lib/getaround_utils/railties/dotenv.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails/railtie'
+
+module GetaroundUtils; end
+
+module GetaroundUtils::Railties; end
+
+class GetaroundUtils::Railties::Dotenv < Rails::Railtie
+  def load
+    if ENV['DOTENVS'].present?
+      overrides = ENV['DOTENVS'].split(',').map{ |n| [".env.#{n}.local", ".env.#{n}"] }.flatten
+      warn('=' * 100)
+      warn("⚠️  ENV is overriden with the following profiles: #{overrides}")
+      warn('=' * 100)
+      Dotenv.load(*overrides)
+    end
+    Dotenv::Railtie.load
+    Dotenv.load('.env.all', '.env.all.local')
+    nil
+  end
+end


### PR DESCRIPTION
# What?
- Add `GetaroundUtils::Railties::Dotenv`

# Why?
- See https://github.com/drivy/drivy-rails/pull/32902 / https://github.com/drivy/drivy-rangers/pull/789
- No specs because this is a minefield of side-effects

# Todo
This can be added in a Ruby/Rails project with:
```
# config/application.rb
require 'getaround_utils/railties/dotenv'
if defined?(Dotenv)
  GetaroundUtils::Railties::Dotenv.load
end
```

- [ ] Update `drivy-rails`
- [ ] Update `drivy-rangers`
- [ ] Add in `captur`
- [ ] Add in `drivy-tools`
- [ ] Add in `drivy-tools-dummy`