### PR TITLE
Dotenv: fix .env.all.local precedence

### DIFF
--- a/getaround_utils/lib/getaround_utils/railties/dotenv.rb
+++ b/getaround_utils/lib/getaround_utils/railties/dotenv.rb
@@ -16,7 +16,7 @@ class GetaroundUtils::Railties::Dotenv < Rails::Railtie
       Dotenv.load(*overrides)
     end
     Dotenv::Railtie.load
-    Dotenv.load('.env.all', '.env.all.local')
+    Dotenv.load('.env.all.local', '.env.all')
     nil
   end
 end


### PR DESCRIPTION
Currently `.env.all` takes precedence over `.env.all.local`.
It needs to be the other way around.

From the [dotenv documentation](https://github.com/bkeepers/dotenv#sinatra-or-plain-ol-ruby):

> The first value set for a variable will win.