### PR TITLE
Create a health engine to share health endpoints

### DIFF
--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     getaround_utils (0.2.27)
+      rack (~> 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/getaround_utils/Gemfile.lock
+++ b/getaround_utils/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getaround_utils (0.2.27)
+    getaround_utils (0.2.28)
       rack (~> 2.0)
 
 GEM

--- a/getaround_utils/getaround_utils.gemspec
+++ b/getaround_utils/getaround_utils.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |gem|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   end
 
+  # Common dependencies
+  gem.add_dependency 'rack', '~> 2.0'
+
   # Development dependencies
   gem.add_development_dependency 'bundler', '~> 2.0'
   gem.add_development_dependency 'getaround-rubocop', '= 0.2.8'

--- a/getaround_utils/lib/getaround_utils.rb
+++ b/getaround_utils/lib/getaround_utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'getaround_utils/engines'
 require 'getaround_utils/mixins'
 require 'getaround_utils/ougai'
 require 'getaround_utils/utils'

--- a/getaround_utils/lib/getaround_utils/engines.rb
+++ b/getaround_utils/lib/getaround_utils/engines.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'getaround_utils/engines/health'

--- a/getaround_utils/lib/getaround_utils/engines/health.rb
+++ b/getaround_utils/lib/getaround_utils/engines/health.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rack'
+
+module GetaroundUtils; end
+
+module GetaroundUtils::Engines; end
+
+module GetaroundUtils::Engines::Health
+  RELEASE_VERSION_PATH = '/health/release_version'
+  COMMIT_SHA1_PATH = '/health/commit_sha1'
+  MIGRATION_STATUS_PATH = '/health/migration_status'
+  UNDEFINED = 'N/A'
+
+  def self.release_version
+    ENV['HEROKU_RELEASE_VERSION'] || ENV['PORTER_STACK_REVISION'] || ENV['PORTER_POD_REVISION']
+  end
+
+  def self.commit_sha1
+    ENV['HEROKU_SLUG_COMMIT'] || ENV['COMMIT_SHA1']
+  end
+
+  def self.needs_migration?
+    return false unless defined?(ActiveRecord)
+
+    ActiveRecord::Base.connection.migration_context.needs_migration?
+  end
+
+  def self.engine
+    Rack::Builder.new do
+      map RELEASE_VERSION_PATH do
+        use Rack::Head
+
+        run(lambda do |env|
+          req = Rack::Request.new(env)
+          return [405, { 'Content-Type' => 'text/plain' }, []] unless req.get?
+
+          content = GetaroundUtils::Engines::Health.release_version || UNDEFINED
+          [200, { 'Content-Type' => 'text/plain' }, [content]]
+        end)
+      end
+
+      map COMMIT_SHA1_PATH do
+        use Rack::Head
+
+        run(lambda do |env|
+          req = Rack::Request.new(env)
+          return [405, { 'Content-Type' => 'text/plain' }, []] unless req.get?
+
+          content = GetaroundUtils::Engines::Health.commit_sha1 || UNDEFINED
+          [200, { 'Content-Type' => 'text/plain' }, [content]]
+        end)
+      end
+
+      map MIGRATION_STATUS_PATH do
+        use Rack::Head
+
+        run(lambda do |env|
+          req = Rack::Request.new(env)
+          return [405, { 'Content-Type' => 'application/json' }, []] unless req.get?
+
+          content = { needs_migration: GetaroundUtils::Engines::Health.needs_migration? }
+          [200, { 'Content-Type' => 'application/json' }, [JSON.generate(content)]]
+        end)
+      end
+    end
+  end
+end

--- a/getaround_utils/lib/getaround_utils/version.rb
+++ b/getaround_utils/lib/getaround_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetaroundUtils
-  VERSION = '0.2.27'
+  VERSION = '0.2.28'
 end

--- a/getaround_utils/spec/getaround_utils/engines/health_spec.rb
+++ b/getaround_utils/spec/getaround_utils/engines/health_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'getaround_utils/engines/health'
+
+RSpec.describe GetaroundUtils::Engines::Health do
+  describe '.release_version' do
+    subject { described_class.release_version }
+
+    let(:heroku_release_version)  { 'heroku-release-version' }
+    let(:porter_stack_revision)   { 'porter-stack-revision' }
+    let(:porter_pod_revision)     { 'porter-pod-revision' }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('HEROKU_RELEASE_VERSION').and_return(heroku_release_version)
+      allow(ENV).to receive(:[]).with('PORTER_STACK_REVISION').and_return(porter_stack_revision)
+      allow(ENV).to receive(:[]).with('PORTER_POD_REVISION').and_return(porter_pod_revision)
+    end
+
+    context 'with HEROKU_RELEASE_VERSION' do
+      it { is_expected.to eq heroku_release_version }
+    end
+
+    context 'with PORTER_STACK_REVISION' do
+      before do
+        allow(ENV).to receive(:[]).with('HEROKU_RELEASE_VERSION').and_return(nil)
+      end
+
+      it { is_expected.to eq porter_stack_revision }
+    end
+
+    context 'with PORTER_POD_REVISION' do
+      before do
+        allow(ENV).to receive(:[]).with('HEROKU_RELEASE_VERSION').and_return(nil)
+        allow(ENV).to receive(:[]).with('PORTER_STACK_REVISION').and_return(nil)
+      end
+
+      it { is_expected.to eq porter_pod_revision }
+    end
+
+    context 'with no environment variables defined' do
+      before do
+        allow(ENV).to receive(:[]).with('HEROKU_RELEASE_VERSION').and_return(nil)
+        allow(ENV).to receive(:[]).with('PORTER_STACK_REVISION').and_return(nil)
+        allow(ENV).to receive(:[]).with('PORTER_POD_REVISION').and_return(nil)
+      end
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.commit_sha1' do
+    subject { described_class.commit_sha1 }
+
+    let(:heroku_slug_commit)  { 'heroku-slug-commit' }
+    let(:commit_sha1)         { 'commit-sha1' }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('HEROKU_SLUG_COMMIT').and_return(heroku_slug_commit)
+      allow(ENV).to receive(:[]).with('COMMIT_SHA1').and_return(commit_sha1)
+    end
+
+    context 'with HEROKU_SLUG_COMMIT' do
+      it { is_expected.to eq heroku_slug_commit }
+    end
+
+    context 'with COMMIT_SHA1' do
+      before do
+        allow(ENV).to receive(:[]).with('HEROKU_SLUG_COMMIT').and_return(nil)
+      end
+
+      it { is_expected.to eq commit_sha1 }
+    end
+
+    context 'with no environment variables defined' do
+      before do
+        allow(ENV).to receive(:[]).with('HEROKU_SLUG_COMMIT').and_return(nil)
+        allow(ENV).to receive(:[]).with('COMMIT_SHA1').and_return(nil)
+      end
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.needs_migration?' do
+    subject { described_class.needs_migration? }
+
+    context 'when ActiveRecord is not defined' do
+      it { is_expected.to be false }
+    end
+
+    context 'when ActiveRecord is defined' do
+      before do
+        stub_const('ActiveRecord', Class.new)
+        stub_const('ActiveRecord::Base', double(connection: double(migration_context: double(needs_migration?: needs_migration))))
+      end
+
+      # rubocop:disable RSpec/NestedGroups
+      context 'when migration is not required' do
+        let(:needs_migration) { false }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when migration is required' do
+        let(:needs_migration) { true }
+
+        it { is_expected.to be true }
+      end
+      # rubocop:enable RSpec/NestedGroups
+    end
+  end
+
+  describe '.engine' do
+    subject(:response) { request.get(path) }
+
+    let(:request) { Rack::MockRequest.new(described_class.engine) }
+
+    let(:release_version) { nil }
+    let(:commit_sha1)     { nil }
+    let(:needs_migration) { false }
+
+    before do
+      allow(described_class).to receive(:release_version).and_return(release_version)
+      allow(described_class).to receive(:commit_sha1).and_return(commit_sha1)
+      allow(described_class).to receive(:needs_migration?).and_return(needs_migration)
+    end
+
+    shared_examples 'renders undefined' do
+      it 'renders undefined', :aggregate_failures do
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq 'text/plain'
+        expect(response.body).to eq described_class::UNDEFINED
+      end
+    end
+
+    shared_examples 'renders expected body' do
+      it 'renders expected body', :aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq 'text/plain'
+        expect(response.body).to eq expected_body
+      end
+    end
+
+    shared_examples 'only responds to GET' do |content_type:|
+      %i[post put patch delete].each do |http_method|
+        context "with #{http_method.to_s.upcase} request" do
+          subject(:response) { request.send(http_method, path) }
+
+          it 'returns method not allowed', :aggregate_failures do
+            expect(response.status).to eq 405
+            expect(response.content_type).to eq content_type
+            expect(response.body).to eq ""
+          end
+        end
+      end
+    end
+
+    context 'when requesting /health/release_version' do
+      let(:path) { described_class::RELEASE_VERSION_PATH }
+
+      include_examples 'only responds to GET', content_type: 'text/plain'
+      include_examples 'renders undefined'
+
+      # rubocop:disable RSpec/NestedGroups
+      context 'when a release version is found' do
+        let(:release_version) { 'hello' }
+
+        include_examples 'renders expected body' do
+          let(:expected_body) { release_version }
+        end
+      end
+      # rubocop:enable RSpec/NestedGroups
+    end
+
+    context 'when requesting /health/commit_sha1' do
+      let(:path) { described_class::COMMIT_SHA1_PATH }
+
+      include_examples 'only responds to GET', content_type: 'text/plain'
+      include_examples 'renders undefined'
+
+      # rubocop:disable RSpec/NestedGroups
+      context 'when a release version is found' do
+        let(:commit_sha1) { 'world' }
+
+        include_examples 'renders expected body' do
+          let(:expected_body) { commit_sha1 }
+        end
+      end
+      # rubocop:enable RSpec/NestedGroups
+    end
+
+    context 'when requesting /health/migration_status' do
+      let(:path) { described_class::MIGRATION_STATUS_PATH }
+
+      include_examples 'only responds to GET', content_type: 'application/json'
+
+      it 'renders migration status', :aggregate_failures do
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq 'application/json'
+        expect(JSON.parse(response.body)).to eq('needs_migration' => needs_migration)
+      end
+    end
+
+    context 'when requesting unknown path' do
+      let(:path) { '/unknown' }
+
+      it 'returns not found', :aggregate_failures do
+        expect(response.status).to eq 404
+        expect(response.body).to eq "Not Found: #{path}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What?

Create a very light Rack application to share health endpoints between all our apps. 

We'll be able to easily set the rails config

```ruby
Rails.application.configure do |config|
  config.release_revision = GetaroundUtils::Engines::Health.release_version
  config.commit_sha1 = GetaroundUtils::Engines::Health.commit_sha1
end
```

And a Rack application could be mounted like an engine in the application routes

```ruby
Rails.application.routes.draw do
  # ...

  mount GetaroundUtils::Engines::Health.engine, at: '/'

  # ...
end
```

All the logic will be centralized here and shared with all projects, we'll only need to update the gem.

## Why?

We have few apps that are sharing the same health endpoints. It's always a pain to update them all when there is a change.