### PR TITLE
Remove namespace from health routes for clearer inspection

### DIFF
--- a/getaround_utils/lib/getaround_utils/engines/health.rb
+++ b/getaround_utils/lib/getaround_utils/engines/health.rb
@@ -8,9 +8,9 @@ module GetaroundUtils; end
 module GetaroundUtils::Engines; end
 
 module GetaroundUtils::Engines::Health
-  RELEASE_VERSION_PATH = '/health/release_version'
-  COMMIT_SHA1_PATH = '/health/commit_sha1'
-  MIGRATION_STATUS_PATH = '/health/migration_status'
+  RELEASE_VERSION_PATH = '/release_version'
+  COMMIT_SHA1_PATH = '/commit_sha1'
+  MIGRATION_STATUS_PATH = '/migration_status'
   UNDEFINED = 'N/A'
 
   def self.release_version


### PR DESCRIPTION
## What?

Remove `health` namespace from the rack application routes.
This will give the namesapce reponsibility to each project (more flexible, and clearer route inspection)

We will have to change the way we're mounting the engine on projects with

```ruby
mount GetaroundUtils::Engines::Health.engine, at: '/health'
```

And the route inspection will look like

```
$> rails routes
            Prefix Verb URI       Pattern        Controller#Action
                        /health                  #<Rack::Builder:0x000000011593a560 @freeze_app=false, @warmup=nil, @run=nil, @map={"/release_version"=>#<Proc:0x0000000115df2198 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:32>, "/commit_sha1"=>#<Proc:0x0000000115df2120 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:44>, "/migration_status"=>#<Proc:0x0000000115df20a8 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:56>}, @use=[]>
```

*NB: Maybe we should store the `/health` part on Shipit `site.url` and not hardcode it 🤔*

## Why?

We're actually mounting the engine with

```ruby
mount GetaroundUtils::Engines::Health.engine, at: '/'
```

And a `rails routes` command looks like

```
$> rails routes
            Prefix Verb URI Pattern        Controller#Action
                        /                  #<Rack::Builder:0x000000011593a560 @freeze_app=false, @warmup=nil, @run=nil, @map={"/health/release_version"=>#<Proc:0x0000000115df2198 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:32>, "/health/commit_sha1"=>#<Proc:0x0000000115df2120 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:44>, "/health/migration_status"=>#<Proc:0x0000000115df20a8 /Users/cyb-/.rvm/gems/ruby-3.2.2/gems/getaround_utils-0.2.28/lib/getaround_utils/engines/health.rb:56>}, @use=[]>
```

Which is a bit unclear on "what is that" since it's mounted on the root path (we have to dig in the engine inspection to see it's about health endpoints)