### PR TITLE
[getaround_utils] Health check file helper for Kubernetes probes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
   test-getaround_utils:
     docker:
       - image: cimg/ruby:4.0.1
+    environment:
+      CI_WORKING_DIR: /tmp/build/getaround_utils
     working_directory: /tmp/build/getaround_utils
     steps:
       - checkout:

--- a/getaround_utils/CHANGELOG.md
+++ b/getaround_utils/CHANGELOG.md
@@ -10,8 +10,8 @@
     ```ruby
     SIDEKIQ_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('sidekiq')
     Sidekiq.configure_server do |config|
-      config.on(:startup) { SIDEKIQ_HEALTH_FILE.create! }
-      config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.drop! }
+      config.on(:startup) { SIDEKIQ_HEALTH_FILE.create }
+      config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.delete }
     end
     ```
 

--- a/getaround_utils/CHANGELOG.md
+++ b/getaround_utils/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - `GetaroundUtils::Utils::HandleError`: notify Bugsnag only when `BUGSNAG_API_KEY` is configured, otherwise log.
 
+### Added
+
+- `GetaroundUtils::Utils::HealthCheckFile` ([#481](https://github.com/drivy/backend-configs/pull/481))
+    ```ruby
+    SIDEKIQ_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('sidekiq')
+    Sidekiq.configure_server do |config|
+      config.on(:startup) { SIDEKIQ_HEALTH_FILE.create! }
+      config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.drop! }
+    end
+    ```
+
 ## [0.3.4] 2026-02-27
 
 ### Breaking Changes

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -199,3 +199,19 @@ end
 ```
 
 For more details, [read the spec](spec/getaround_utils/utils/handle_error_spec.rb)
+
+### GetaroundUtils::Utils::HealthCheckFile
+
+Helper to easily create health check file used for Kubernetes Probes (Sidekiq, Captur, etc...)
+
+*Example in `config/initializers/sidekiq.rb`*
+```ruby
+SIDEKIQ_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('sidekiq')
+
+Sidekiq.configure_server do |config|
+  config.on(:startup) { SIDEKIQ_HEALTH_FILE.create! }
+  config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.drop! }
+end
+```
+
+For more details, [read the spec](spec/getaround_utils/utils/health_check_file_spec.rb)

--- a/getaround_utils/README.md
+++ b/getaround_utils/README.md
@@ -209,8 +209,8 @@ Helper to easily create health check file used for Kubernetes Probes (Sidekiq, C
 SIDEKIQ_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('sidekiq')
 
 Sidekiq.configure_server do |config|
-  config.on(:startup) { SIDEKIQ_HEALTH_FILE.create! }
-  config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.drop! }
+  config.on(:startup) { SIDEKIQ_HEALTH_FILE.create }
+  config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.delete }
 end
 ```
 

--- a/getaround_utils/lib/getaround_utils/utils.rb
+++ b/getaround_utils/lib/getaround_utils/utils.rb
@@ -3,3 +3,4 @@
 require 'getaround_utils/utils/config_url'
 require 'getaround_utils/utils/deep_key_value'
 require 'getaround_utils/utils/handle_error'
+require 'getaround_utils/utils/health_check_file'

--- a/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
+++ b/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
@@ -19,12 +19,12 @@ class GetaroundUtils::Utils::HealthCheckFile
     @path = @base_path.join(FILE_NAME)
   end
 
-  def touch
+  def create
     FileUtils.mkdir_p(@base_path)
     FileUtils.touch(@path)
   end
 
-  def unlink
+  def delete
     FileUtils.rm_f(@path)
   end
 

--- a/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
+++ b/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
@@ -19,12 +19,12 @@ class GetaroundUtils::Utils::HealthCheckFile
     @path = @base_path.join(FILE_NAME)
   end
 
-  def create!
+  def touch
     FileUtils.mkdir_p(@base_path)
     FileUtils.touch(@path)
   end
 
-  def drop!
+  def unlink
     FileUtils.rm_f(@path)
   end
 

--- a/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
+++ b/getaround_utils/lib/getaround_utils/utils/health_check_file.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'pathname'
+
+module GetaroundUtils; end
+
+module GetaroundUtils::Utils; end
+
+class GetaroundUtils::Utils::HealthCheckFile
+  FILE_NAME = 'health_check_file'
+
+  attr_reader :path
+
+  def initialize(name)
+    raise ArgumentError, "Expected name as String, got: #{name.inspect}" if !name.is_a?(String) || name.empty?
+
+    @base_path = root_path.join('tmp', name)
+    @path = @base_path.join(FILE_NAME)
+  end
+
+  def create!
+    FileUtils.mkdir_p(@base_path)
+    FileUtils.touch(@path)
+  end
+
+  def drop!
+    FileUtils.rm_f(@path)
+  end
+
+  def exists?
+    File.exist?(@path)
+  end
+
+  private
+
+  def root_path
+    defined?(::Rails) ? Rails.root : Pathname.new('/')
+  end
+end

--- a/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
   end
 
   describe '#touch' do
-    subject { health_file.touch }
+    subject { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
 
     include_context 'with clean filesystem'
 
@@ -58,7 +58,7 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
 
     include_context 'with clean filesystem'
 
-    before { health_file.touch }
+    before { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
 
     it 'removes the file' do
       expect(File.exist?(expected_file_path)).to be true
@@ -77,7 +77,7 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
 
     context 'when file was already created' do
-      before { health_file.touch }
+      before { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
 
       it { is_expected.to be true }
     end

--- a/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
+  subject(:health_file) { described_class.new(name) }
+
+  let(:name) { 'dummy' }
+
+  let(:root_path) { Pathname.new(ENV.fetch('CI_WORKING_DIR', '/')) }
+  let(:expected_base_path) { root_path.join('tmp', name) }
+  let(:expected_file_path) { expected_base_path.join(described_class::FILE_NAME) }
+
+  shared_context 'with clean filesystem' do
+    around do |example|
+      FileUtils.rm_rf(expected_base_path)
+      example.run
+      FileUtils.rm_rf(expected_base_path)
+    end
+  end
+
+  context 'with invalid name' do
+    let(:name) { '' }
+
+    it { expect { subject }.to raise_error(ArgumentError, /Expected name as String/) }
+  end
+
+  describe '#path' do
+    subject { health_file.path }
+
+    it { is_expected.to eq(expected_file_path) }
+
+    context 'with Rails defined' do
+      let(:root_path) { Pathname.new('/dummy') }
+
+      before do
+        stub_const('Rails', double(root: root_path))
+      end
+
+      it { is_expected.to eq(expected_file_path) }
+    end
+  end
+
+  describe '#create!' do
+    subject { health_file.create! }
+
+    include_context 'with clean filesystem'
+
+    it 'creates the file' do
+      expect(File.exist?(expected_file_path)).to be false
+      subject
+      expect(File.exist?(expected_file_path)).to be true
+    end
+  end
+
+  describe '#drop!' do
+    subject { health_file.drop! }
+
+    include_context 'with clean filesystem'
+
+    before { health_file.create! }
+
+    it 'removes the file' do
+      expect(File.exist?(expected_file_path)).to be true
+      subject
+      expect(File.exist?(expected_file_path)).to be false
+    end
+  end
+
+  describe '#exists?' do
+    subject { health_file.exists? }
+
+    include_context 'with clean filesystem'
+
+    context 'when file is not yet created' do
+      it { is_expected.to be false }
+    end
+
+    context 'when file was already created' do
+      before { health_file.create! }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
   end
 
-  describe '#create!' do
-    subject { health_file.create! }
+  describe '#touch' do
+    subject { health_file.touch }
 
     include_context 'with clean filesystem'
 
@@ -53,12 +53,12 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
   end
 
-  describe '#drop!' do
-    subject { health_file.drop! }
+  describe '#unlink' do
+    subject { health_file.unlink }
 
     include_context 'with clean filesystem'
 
-    before { health_file.create! }
+    before { health_file.touch }
 
     it 'removes the file' do
       expect(File.exist?(expected_file_path)).to be true
@@ -77,7 +77,7 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
 
     context 'when file was already created' do
-      before { health_file.create! }
+      before { health_file.touch }
 
       it { is_expected.to be true }
     end

--- a/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/health_check_file_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
   end
 
-  describe '#touch' do
-    subject { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
+  describe '#create' do
+    subject { health_file.create }
 
     include_context 'with clean filesystem'
 
@@ -53,12 +53,12 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
   end
 
-  describe '#unlink' do
-    subject { health_file.unlink }
+  describe '#delete' do
+    subject { health_file.delete }
 
     include_context 'with clean filesystem'
 
-    before { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
+    before { health_file.create }
 
     it 'removes the file' do
       expect(File.exist?(expected_file_path)).to be true
@@ -77,7 +77,7 @@ RSpec.describe GetaroundUtils::Utils::HealthCheckFile do
     end
 
     context 'when file was already created' do
-      before { health_file.touch } # rubocop:disable Rails/SkipsModelValidations
+      before { health_file.create }
 
       it { is_expected.to be true }
     end


### PR DESCRIPTION
## What?

Introduce `GetaroundUtils::Utils::HealthCheckFile`

#### Example usage

- *In `config/initializers/sidekiq.rb`*
  ```ruby
  SIDEKIQ_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('sidekiq')

  Sidekiq.configure_server do |config|
    config.on(:startup) { SIDEKIQ_HEALTH_FILE.create }
    config.on(:shutdown) { SIDEKIQ_HEALTH_FILE.delete }
  end
  ```
- *In `config/initializers/solid_queue.rb`*
  ```ruby
  SOLID_QUEUE_HEALTH_FILE = GetaroundUtils::Utils::HealthCheckFile.new('solid_queue')

  SolidQueue.on_start { SOLID_QUEUE_HEALTH_FILE.create }
  SolidQueue.on_stop { SOLID_QUEUE_HEALTH_FILE.delete }
  ```
- *etc...*


## Why?

This is pretty useful on almost all our projects for Sidekiq probes *(already in use in drivy-rails, Shipit, Rangers)*, and could also be used for Captur consumer or Solid Queue probes