### PR TITLE
[getaround_utils] Improve error handler

### DIFF
--- a/getaround_utils/CHANGELOG.md
+++ b/getaround_utils/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- `GetaroundUtils::Utils::HandleError`: notify Bugsnag only when `BUGSNAG_API_KEY` is configured, otherwise log.
+
 ## [0.3.4] 2026-02-27
 
 ### Breaking Changes

--- a/getaround_utils/lib/getaround_utils/utils/handle_error.rb
+++ b/getaround_utils/lib/getaround_utils/utils/handle_error.rb
@@ -11,7 +11,7 @@ module GetaroundUtils::Utils::HandleError
 
   # @see https://docs.bugsnag.com/platforms/ruby/rails/reporting-handled-errors/#sending-custom-diagnostics
   def self.notify_of(error, **metadata, &)
-    if defined?(::Bugsnag)
+    if defined?(::Bugsnag) && ENV.key?('BUGSNAG_API_KEY')
       ::Bugsnag.notify(error) do |event|
         metadata.each do |name, value|
           if value.is_a?(Hash)

--- a/getaround_utils/lib/getaround_utils/utils/handle_error.rb
+++ b/getaround_utils/lib/getaround_utils/utils/handle_error.rb
@@ -11,7 +11,7 @@ module GetaroundUtils::Utils::HandleError
 
   # @see https://docs.bugsnag.com/platforms/ruby/rails/reporting-handled-errors/#sending-custom-diagnostics
   def self.notify_of(error, **metadata, &)
-    if defined?(::Bugsnag) && ENV.key?('BUGSNAG_API_KEY')
+    if defined?(::Bugsnag) && ::Bugsnag.configuration.api_key
       ::Bugsnag.notify(error) do |event|
         metadata.each do |name, value|
           if value.is_a?(Hash)

--- a/getaround_utils/spec/getaround_utils/utils/handle_error_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/handle_error_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe GetaroundUtils::Utils::HandleError do
+  # rubocop:disable RSpec/NestedGroups
   describe '.notify_of' do
     let(:error) { RuntimeError.new('woopsie') }
 
@@ -13,25 +14,32 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
     shared_context 'with Bugsnag defined' do
       let(:bugsnag) { double }
       let(:event)   { double }
+      let(:env_api_key) { true }
 
       before do
+        allow(ENV).to receive(:key?).and_call_original
+        allow(ENV).to receive(:key?).with('BUGSNAG_API_KEY').and_return(env_api_key)
         allow(event).to receive(:add_metadata)
         allow(bugsnag).to receive(:notify).and_yield(event)
         stub_const('Bugsnag', bugsnag)
       end
     end
 
-    it 'logs the handled error', :aggregate_failures do
-      expect { |b| described_class.notify_of(error, &b) }.not_to yield_control
-      expect(described_class)
-        .to have_received(:loggable_log)
-        .with(
-          :debug,
-          'handled_error',
-          error_class: 'RuntimeError',
-          error_message: 'woopsie'
-        )
+    shared_examples 'logs the handled error' do
+      it 'logs the handled error', :aggregate_failures do
+        expect { |b| described_class.notify_of(error, &b) }.not_to yield_control
+        expect(described_class)
+          .to have_received(:loggable_log)
+          .with(
+            :debug,
+            'handled_error',
+            error_class: 'RuntimeError',
+            error_message: 'woopsie'
+          )
+      end
     end
+
+    it_behaves_like 'logs the handled error'
 
     context 'when Bugsnag is defined' do
       include_context 'with Bugsnag defined'
@@ -40,6 +48,12 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
         expect { |b| described_class.notify_of(error, &b) }.to yield_with_args(event)
         expect(bugsnag).to have_received(:notify).with(error)
         expect(event).not_to have_received(:add_metadata)
+      end
+
+      context 'without environment api key' do
+        let(:env_api_key) { false }
+
+        it_behaves_like 'logs the handled error'
       end
     end
 
@@ -53,20 +67,23 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
         }
       end
 
-      it 'logs the handled error with given metadata', :aggregate_failures do
-        expect { |b| described_class.notify_of(error, **metadata, &b) }.not_to yield_control
-        expect(described_class)
-          .to have_received(:loggable_log)
-          .with(
-            :debug,
-            'handled_error',
-            error_class: 'RuntimeError',
-            error_message: 'woopsie',
-            **metadata
-          )
+      shared_examples 'logs the handled error with given metadata' do
+        it 'logs the handled error with given metadata', :aggregate_failures do
+          expect { |b| described_class.notify_of(error, **metadata, &b) }.not_to yield_control
+          expect(described_class)
+            .to have_received(:loggable_log)
+            .with(
+              :debug,
+              'handled_error',
+              error_class: 'RuntimeError',
+              error_message: 'woopsie',
+              **metadata
+            )
+        end
       end
 
-      # rubocop:disable RSpec/NestedGroups
+      it_behaves_like 'logs the handled error with given metadata'
+
       context 'when Bugsnag is defined' do
         include_context 'with Bugsnag defined'
 
@@ -76,8 +93,14 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
           expect(event).to have_received(:add_metadata).with('custom', :foo, 'bar')
           expect(event).to have_received(:add_metadata).with(:baz, { hello: 'world' })
         end
+
+        context 'without environment api key' do
+          let(:env_api_key) { false }
+
+          it_behaves_like 'logs the handled error with given metadata'
+        end
       end
-      # rubocop:enable RSpec/NestedGroups
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 end

--- a/getaround_utils/spec/getaround_utils/utils/handle_error_spec.rb
+++ b/getaround_utils/spec/getaround_utils/utils/handle_error_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
     end
 
     shared_context 'with Bugsnag defined' do
+      let(:api_key) { 'my-api-key' }
       let(:bugsnag) { double }
       let(:event)   { double }
-      let(:env_api_key) { true }
+      let(:config)  { double(api_key:) }
 
       before do
-        allow(ENV).to receive(:key?).and_call_original
-        allow(ENV).to receive(:key?).with('BUGSNAG_API_KEY').and_return(env_api_key)
         allow(event).to receive(:add_metadata)
         allow(bugsnag).to receive(:notify).and_yield(event)
+        allow(bugsnag).to receive(:configuration).and_return(config)
         stub_const('Bugsnag', bugsnag)
       end
     end
@@ -50,8 +50,8 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
         expect(event).not_to have_received(:add_metadata)
       end
 
-      context 'without environment api key' do
-        let(:env_api_key) { false }
+      context 'without configured api key' do
+        let(:api_key) { nil }
 
         it_behaves_like 'logs the handled error'
       end
@@ -94,8 +94,8 @@ RSpec.describe GetaroundUtils::Utils::HandleError do
           expect(event).to have_received(:add_metadata).with(:baz, { hello: 'world' })
         end
 
-        context 'without environment api key' do
-          let(:env_api_key) { false }
+        context 'without configured api key' do
+          let(:api_key) { nil }
 
           it_behaves_like 'logs the handled error with given metadata'
         end


### PR DESCRIPTION
## What?

Notify Bugsnag about handled errors only when `BUGSNAG_API_KEY` environment variable is configured, otherwise log.

## Why?

This will make handled errors locally logged on console instead of the Bugsnag error message:

```
Could not notify because of invalid API key
```